### PR TITLE
Fix a bug where if some options don't exist on a library it fails to deserialise it causing a crash

### DIFF
--- a/custom_components/audiobookshelf/const.py
+++ b/custom_components/audiobookshelf/const.py
@@ -2,7 +2,7 @@
 
 from homeassistant.const import Platform
 
-VERSION = "v0.2.2"
+VERSION = "v0.2.3"
 ISSUE_URL = "https://github.com/wolffshots/hass-audiobookshelf/issues"
 DOMAIN = "audiobookshelf"
 PLATFORMS: list[Platform] = [Platform.SENSOR]

--- a/custom_components/audiobookshelf/manifest.json
+++ b/custom_components/audiobookshelf/manifest.json
@@ -13,5 +13,5 @@
   "requirements": [
     "aiohttp"
   ],
-  "version": "0.2.2"
+  "version": "0.2.3"
 }

--- a/custom_components/audiobookshelf/sensor.py
+++ b/custom_components/audiobookshelf/sensor.py
@@ -160,7 +160,7 @@ class LibraryFolder:
     """Class representing a folder in an Audiobookshelf library."""
 
     id: str
-    full_path: str
+    full_path: str | None
     library_id: str
     added_at: int | None
 
@@ -174,7 +174,7 @@ class LibrarySettings:
     auto_scan_cron_expression: str | None
     skip_matching_media_with_asin: bool | None
     skip_matching_media_with_isbn: bool | None
-    audiobooks_only: bool
+    audiobooks_only: bool | None
     epubs_allow_scripted_content: bool | None
     hide_single_book_series: bool | None
     only_show_later_books_in_continue_series: bool | None
@@ -192,9 +192,9 @@ class Library:
     folders: list[LibraryFolder] | None
     display_order: int | None
     icon: str | None
-    media_type: str
+    media_type: str | None
     provider: str | None
-    settings: LibrarySettings
+    settings: LibrarySettings | None
     last_scan: int | None
     last_scan_version: str | None
     created_at: int | None


### PR DESCRIPTION
This pull request includes several updates to the `audiobookshelf` custom component. The most important changes involve updating the version, adjusting type annotations, and modifying class attributes to support `None` values.

### Version Updates:
* [`custom_components/audiobookshelf/const.py`](diffhunk://#diff-ea3db6eaed407d9e61d8e8861982e588c33f689b2aa505bd74c1b62bb2191cf0L5-R5): Updated `VERSION` to "v0.2.3".
* [`custom_components/audiobookshelf/manifest.json`](diffhunk://#diff-9dda85fe5cbbbf8a8921dfec3b702bed17b3acb0c1d4a11d3146f57efa7673b2L16-R16): Updated `version` to "0.2.3".

### Type Annotation and Attribute Modifications:
* [`custom_components/audiobookshelf/sensor.py`](diffhunk://#diff-b46e585e2762e22fecc5e4677c2c19b1e5f6d3a2b4ff596bc93207405e093305L163-R163): Modified `full_path` attribute in `LibraryFolder` class to support `None` values.
* [`custom_components/audiobookshelf/sensor.py`](diffhunk://#diff-b46e585e2762e22fecc5e4677c2c19b1e5f6d3a2b4ff596bc93207405e093305L177-R177): Modified `audiobooks_only` attribute in `LibrarySettings` class to support `None` values.
* [`custom_components/audiobookshelf/sensor.py`](diffhunk://#diff-b46e585e2762e22fecc5e4677c2c19b1e5f6d3a2b4ff596bc93207405e093305L195-R197): Modified `media_type` and `settings` attributes in `Library` class to support `None` values.