### PR TITLE
fix: guard the destructive paths and stop silent polling failures

### DIFF
--- a/custom_components/audiobookshelf/audiobook_shelf_data_update_coordinator.py
+++ b/custom_components/audiobookshelf/audiobook_shelf_data_update_coordinator.py
@@ -24,6 +24,8 @@ from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 from mashumaro.types import Alias
 
+from .const import REQUEST_TIMEOUT
+
 _LOGGER = getLogger(__name__)
 
 API_DATA_METHODS = [
@@ -105,6 +107,7 @@ class AudiobookShelfDataUpdateCoordinator(DataUpdateCoordinator):
         """Initialize."""
         self.api_url = api_url
         self.token = token
+        self.libraries: list[Library] = []
 
         super().__init__(
             hass,
@@ -125,6 +128,7 @@ class AudiobookShelfDataUpdateCoordinator(DataUpdateCoordinator):
                     logger=_LOGGER,
                     pagination_items_per_page=30,
                     token=self.token,
+                    timeout=REQUEST_TIMEOUT,
                 ),
             )
         return self._client
@@ -179,11 +183,15 @@ class AudiobookShelfDataUpdateCoordinator(DataUpdateCoordinator):
         for library in libraries:
             response = await client._get(f"api/libraries/{library.id_}/stats")  # noqa: SLF001
             stats[library.id_] = LibraryStats.from_json(response)
+        # Kept so the sensor platform can name its entities without issuing a
+        # second /api/libraries call of its own.
+        self.libraries = libraries
         return stats
 
     async def _async_update_data(self) -> dict:
         """Fetch data from API endpoint."""
         data = {}
+        method = ""
         try:
             for method in API_DATA_METHODS:
                 _LOGGER.debug("Fetched %s", method)
@@ -195,6 +203,14 @@ class AudiobookShelfDataUpdateCoordinator(DataUpdateCoordinator):
             raise ConfigEntryAuthFailed(msg) from err
         except (AbsError, ClientError) as err:
             msg = "Error fetching data"
+            raise UpdateFailed(msg) from err
+        except (ValueError, LookupError) as err:
+            # Every from_json call raises mashumaro's MissingField (LookupError)
+            # or InvalidFieldValue (ValueError) on schema drift, and a non-JSON
+            # body raises JSONDecodeError (ValueError). None of these are
+            # AbsError or ClientError, so without this they escape as an
+            # unhandled exception and log a traceback on every poll.
+            msg = f"Unexpected response from Audiobookshelf fetching {method}"
             raise UpdateFailed(msg) from err
         else:
             return data

--- a/custom_components/audiobookshelf/config_flow.py
+++ b/custom_components/audiobookshelf/config_flow.py
@@ -18,7 +18,7 @@ if TYPE_CHECKING:
 
     from homeassistant.config_entries import ConfigFlowResult
 
-from .const import DOMAIN
+from .const import DOMAIN, REQUEST_TIMEOUT
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -48,6 +48,7 @@ async def verify_config(data: dict[str, str]) -> dict:
                     token=data[CONF_API_KEY],
                     logger=_LOGGER,
                     pagination_items_per_page=30,
+                    timeout=REQUEST_TIMEOUT,
                 ),
             )
     except BadUserError:

--- a/custom_components/audiobookshelf/config_flow.py
+++ b/custom_components/audiobookshelf/config_flow.py
@@ -95,7 +95,6 @@ class AudiobookshelfConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                     errors=errors,
                 )
 
-            await self.async_set_unique_id("Audiobookshelf")
             return self.async_create_entry(
                 title="Audiobookshelf",
                 data={

--- a/custom_components/audiobookshelf/const.py
+++ b/custom_components/audiobookshelf/const.py
@@ -1,7 +1,14 @@
 """Constants for the Audiobookshelf integration."""
 
+from aiohttp import ClientTimeout
 from homeassistant.const import Platform
 
 VERSION = "v0.3.0"
 DOMAIN = "audiobookshelf"
 PLATFORMS: list[Platform] = [Platform.SENSOR]
+
+# aiohttp defaults to a five minute total timeout per request. A single poll
+# issues five requests plus one per library, so a server that accepts
+# connections but stops responding can hold a poll open for far longer than
+# the scan interval, with no error and no sign of staleness.
+REQUEST_TIMEOUT = ClientTimeout(total=30)

--- a/custom_components/audiobookshelf/manifest.json
+++ b/custom_components/audiobookshelf/manifest.json
@@ -13,5 +13,6 @@
   "requirements": [
     "aioaudiobookshelf"
   ],
+  "single_config_entry": true,
   "version": "0.3.0"
 }

--- a/custom_components/audiobookshelf/sensor.py
+++ b/custom_components/audiobookshelf/sensor.py
@@ -92,8 +92,12 @@ async def async_setup_entry(
 
     sensors_descriptions: list[AudiobookShelfSensorEntityDescription] = []
     sensors_descriptions.extend(SENSOR_DESCRIPTIONS)
-    libraries = await coordinator.get_libraries()
-    for library in libraries:
+    # Populated by the first refresh, which has already run and would have
+    # aborted setup had it failed. Calling the API again here would be a second
+    # chance to fail, and a failure leaves the entry loaded with no entities at
+    # all - which also stops the coordinator polling, since it only schedules
+    # a refresh while it has listeners.
+    for library in coordinator.libraries:
         sensors_descriptions.extend(
             [
                 AudiobookShelfSensorEntityDescription(
@@ -155,17 +159,29 @@ class AudiobookShelfSensor(CoordinatorEntity, SensorEntity):
         super().__init__(coordinator, None)
 
     @property
+    def available(self) -> bool:
+        """Return whether the library this sensor tracks still exists."""
+        key_context = self.entity_description.key_context
+        if key_context is None:
+            return super().available
+        return super().available and key_context in self.coordinator.data.get(
+            self.entity_description.key, {}
+        )
+
+    @property
     def native_value(self) -> Any | None:
         """Return the state of the sensor."""
         native_value = self.coordinator.data.get(self.entity_description.key)
         if self.entity_description.key_context is not None and native_value is not None:
-            native_value = native_value[self.entity_description.key_context]
+            # A library deleted on the server drops out of library_stats while
+            # its entities live on, so this lookup has to tolerate a miss.
+            native_value = native_value.get(self.entity_description.key_context)
         if (
             self.entity_description.key_context_method is not None
             and native_value is not None
         ):
             native_value = getattr(
-                native_value, self.entity_description.key_context_method
+                native_value, self.entity_description.key_context_method, None
             )
         return native_value
 

--- a/custom_components/audiobookshelf/services.py
+++ b/custom_components/audiobookshelf/services.py
@@ -3,6 +3,8 @@
 from logging import getLogger
 from typing import TYPE_CHECKING
 
+import homeassistant.helpers.config_validation as cv
+import voluptuous as vol
 from aioaudiobookshelf.schema.library import (
     LibraryItemMinifiedBook,
     LibraryItemMinifiedPodcast,
@@ -20,6 +22,19 @@ SERVICE_ATTRIBUTE_SERIES_NAME = "series_name"
 
 SUPPORTED_SERVICES = (SERVICE_REMOVE_PROGRESS,)
 
+# The match is a substring test against every item in every library, and the
+# deletion cannot be undone, so an empty or blank name must never reach the
+# handler - it would match every book on the server.
+SERVICE_SCHEMAS = {
+    SERVICE_REMOVE_PROGRESS: vol.Schema(
+        {
+            vol.Required(SERVICE_ATTRIBUTE_SERIES_NAME): vol.All(
+                cv.string, vol.Strip, vol.Length(min=1)
+            ),
+        }
+    ),
+}
+
 _LOGGER = getLogger(__name__)
 
 
@@ -29,7 +44,7 @@ def async_setup_services(hass: HomeAssistant) -> bool:
     async def async_handle_remove_progress(call: ServiceCall) -> None:
         """Handle the remove progress service call."""
         coordinator: AudiobookShelfDataUpdateCoordinator = hass.data[DOMAIN]
-        series_name = call.data.get(SERVICE_ATTRIBUTE_SERIES_NAME)
+        series_name: str = call.data[SERVICE_ATTRIBUTE_SERIES_NAME].casefold()
 
         client = await coordinator.get_client()
         libraries = await client.get_all_libraries()
@@ -45,8 +60,7 @@ def async_setup_services(hass: HomeAssistant) -> bool:
                         item_series_name = lib_item_minified.media.metadata.series_name
                         if (
                             isinstance(item_series_name, str)
-                            and isinstance(series_name, str)
-                            and series_name in item_series_name
+                            and series_name in item_series_name.casefold()
                         ):
                             media_progress = await client.get_my_media_progress(
                                 item_id=lib_item_minified.id_
@@ -75,7 +89,9 @@ def async_setup_services(hass: HomeAssistant) -> bool:
         SERVICE_REMOVE_PROGRESS: async_handle_remove_progress,
     }
     for service in SUPPORTED_SERVICES:
-        hass.services.async_register(DOMAIN, service, services[service])
+        hass.services.async_register(
+            DOMAIN, service, services[service], schema=SERVICE_SCHEMAS[service]
+        )
 
     return True
 

--- a/custom_components/audiobookshelf/services.yaml
+++ b/custom_components/audiobookshelf/services.yaml
@@ -3,4 +3,5 @@ remove_my_progress:
     series_name:
       required: true
       example: construction site
-      default: true
+      selector:
+        text:

--- a/custom_components/audiobookshelf/translations/en.json
+++ b/custom_components/audiobookshelf/translations/en.json
@@ -34,11 +34,11 @@
     "services": {
         "remove_my_progress": {
             "name": "Remove My Progress",
-            "description": "Remove listening progress for library items.",
+            "description": "Remove listening progress for library items. This cannot be undone.",
             "fields": {
                 "series_name": {
-                    "name": "series name to match for removal",
-                    "description": ""
+                    "name": "Series name",
+                    "description": "Text matched against series names, ignoring case. Progress is removed from every book whose series contains this text, in every library, for the account the API key belongs to."
                 }
             }
         }

--- a/tests/test_coordinator_errors.py
+++ b/tests/test_coordinator_errors.py
@@ -1,0 +1,130 @@
+"""Tests for how the coordinator maps API failures onto Home Assistant errors."""
+
+import asyncio
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from aioaudiobookshelf.exceptions import ApiError, NotFoundError, TokenIsMissingError
+from homeassistant.exceptions import ConfigEntryAuthFailed
+from homeassistant.helpers.update_coordinator import UpdateFailed
+
+from custom_components.audiobookshelf.audiobook_shelf_data_update_coordinator import (
+    AudiobookShelfDataUpdateCoordinator,
+)
+
+LIBRARY_STATS = (
+    b'{"totalAuthors": 1, "totalGenres": 3, "totalItems": 12, "totalSize": 1024,'
+    b' "totalDuration": 60.5, "numAudioTracks": 40}'
+)
+OPEN_SESSIONS = b'{"sessions": []}'
+USERS = b'{"users": []}'
+USERS_ONLINE = b'{"usersOnline": []}'
+AUTH_SESSIONS = b'{"total": 2}'
+
+
+def _coordinator() -> AudiobookShelfDataUpdateCoordinator:
+    """Build a coordinator with Home Assistant stubbed out."""
+    with patch.object(
+        AudiobookShelfDataUpdateCoordinator, "__init__", return_value=None
+    ):
+        coordinator = AudiobookShelfDataUpdateCoordinator(  # type: ignore[call-arg]
+            MagicMock(), MagicMock(), 300, "http://abs", "token"
+        )
+    coordinator.api_url = "http://abs"
+    coordinator.token = "api-key"  # noqa: S105
+    coordinator.libraries = []
+    return coordinator
+
+
+def _with_client(responses: dict[str, Any]) -> AudiobookShelfDataUpdateCoordinator:
+    """Return a coordinator whose client answers endpoints from a mapping."""
+    coordinator = _coordinator()
+
+    async def _get(endpoint: str) -> Any:
+        """Return the mapped response, raising it instead if it is an exception."""
+        response = responses[endpoint]
+        if isinstance(response, Exception):
+            raise response
+        return response
+
+    client = MagicMock()
+    client._get = AsyncMock(side_effect=_get)  # noqa: SLF001
+    # SimpleNamespace rather than MagicMock: "name" is a reserved constructor
+    # argument on Mock and would not read back as an attribute.
+    client.get_all_libraries = AsyncMock(
+        return_value=[SimpleNamespace(id_="lib-1", name="Books")]
+    )
+    coordinator.get_client = AsyncMock(return_value=client)  # type: ignore[method-assign]
+    return coordinator
+
+
+def _endpoints(**overrides: Any) -> dict[str, Any]:
+    """Build a full set of healthy endpoint responses, with optional overrides."""
+    endpoints = {
+        "api/users": USERS,
+        "api/users/online": USERS_ONLINE,
+        "api/sessions/open": OPEN_SESSIONS,
+        "api/me/sessions": AUTH_SESSIONS,
+        "api/libraries/lib-1/stats": LIBRARY_STATS,
+    }
+    endpoints.update(overrides)
+    return endpoints
+
+
+def test_happy_path_derives_count_libraries() -> None:
+    """A healthy poll counts the libraries it gathered stats for."""
+    coordinator = _with_client(_endpoints())
+    data = asyncio.run(coordinator._async_update_data())  # noqa: SLF001
+    assert data["count_libraries"] == 1
+    assert data["count_auth_sessions"] == 2
+    assert coordinator.libraries[0].name == "Books"
+
+
+def test_auth_error_triggers_reauth() -> None:
+    """A missing token surfaces as AbsAuthError and must prompt for reauth."""
+    coordinator = _with_client(
+        _endpoints(**{"api/users": TokenIsMissingError("no token")})
+    )
+    with pytest.raises(ConfigEntryAuthFailed):
+        asyncio.run(coordinator._async_update_data())  # noqa: SLF001
+
+
+def test_api_error_is_update_failed() -> None:
+    """A non-auth API error must not prompt for reauth."""
+    coordinator = _with_client(_endpoints(**{"api/users": ApiError("boom")}))
+    with pytest.raises(UpdateFailed):
+        asyncio.run(coordinator._async_update_data())  # noqa: SLF001
+
+
+def test_not_found_is_update_failed_not_reauth() -> None:
+    """A 404 on a required endpoint is a failure, not an auth problem."""
+    coordinator = _with_client(_endpoints(**{"api/users": NotFoundError("gone")}))
+    with pytest.raises(UpdateFailed):
+        asyncio.run(coordinator._async_update_data())  # noqa: SLF001
+
+
+def test_auth_sessions_degrade_to_none_on_404() -> None:
+    """Servers older than 2.36.0 lack /api/me/sessions and must still poll."""
+    coordinator = _with_client(
+        _endpoints(**{"api/me/sessions": NotFoundError("no such endpoint")})
+    )
+    data = asyncio.run(coordinator._async_update_data())  # noqa: SLF001
+    assert data["count_auth_sessions"] is None
+    assert data["count_libraries"] == 1
+
+
+@pytest.mark.parametrize(
+    "body",
+    [
+        pytest.param(b'{"totalGenres": 3}', id="missing-required-field"),
+        pytest.param(b'{"totalItems": null}', id="null-where-int-expected"),
+        pytest.param(b"<html>not json</html>", id="non-json-body"),
+    ],
+)
+def test_schema_drift_is_update_failed(body: bytes) -> None:
+    """Parse failures are neither AbsError nor ClientError and must be caught."""
+    coordinator = _with_client(_endpoints(**{"api/libraries/lib-1/stats": body}))
+    with pytest.raises(UpdateFailed, match="library_stats"):
+        asyncio.run(coordinator._async_update_data())  # noqa: SLF001

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -1,0 +1,71 @@
+"""Tests for how sensors read values out of the coordinator's data."""
+
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+from custom_components.audiobookshelf.sensor import (
+    AudiobookShelfSensor,
+    AudiobookShelfSensorEntityDescription,
+)
+
+LIBRARY_SENSOR = AudiobookShelfSensorEntityDescription(
+    key="library_stats",
+    key_context="lib-1",
+    key_context_method="total_items",
+    name="Audiobookshelf Books Items",
+)
+GLOBAL_SENSOR = AudiobookShelfSensorEntityDescription(key="count_users")
+
+
+def _sensor(
+    description: AudiobookShelfSensorEntityDescription, data: dict[str, Any]
+) -> AudiobookShelfSensor:
+    """Build a sensor over a coordinator holding the given data."""
+    coordinator = MagicMock()
+    coordinator.data = data
+    coordinator.last_update_success = True
+    with patch.object(AudiobookShelfSensor, "__init__", return_value=None):
+        sensor = AudiobookShelfSensor(coordinator, description)  # type: ignore[call-arg]
+    sensor.coordinator = coordinator
+    sensor.entity_description = description
+    return sensor
+
+
+def test_library_sensor_reads_its_stat() -> None:
+    """A present library reports the requested stat."""
+    data = {"library_stats": {"lib-1": SimpleNamespace(total_items=12)}}
+    sensor = _sensor(LIBRARY_SENSOR, data)
+    assert sensor.native_value == 12
+    assert sensor.available is True
+
+
+def test_library_removed_server_side_does_not_raise() -> None:
+    """A library deleted on the server leaves entities behind that must not raise."""
+    data: dict[str, Any] = {"library_stats": {"lib-2": SimpleNamespace(total_items=3)}}
+    sensor = _sensor(LIBRARY_SENSOR, data)
+    assert sensor.native_value is None
+    assert sensor.available is False
+
+
+def test_missing_stat_field_does_not_raise() -> None:
+    """A stat dropped from the API response reads as unknown, not an error."""
+    data = {"library_stats": {"lib-1": SimpleNamespace()}}
+    sensor = _sensor(LIBRARY_SENSOR, data)
+    assert sensor.native_value is None
+
+
+def test_global_sensor_is_unaffected_by_library_stats() -> None:
+    """Sensors without a key context ignore the library availability check."""
+    sensor = _sensor(GLOBAL_SENSOR, {"count_users": 4, "library_stats": {}})
+    assert sensor.native_value == 4
+    assert sensor.available is True
+
+
+def test_none_value_stays_none() -> None:
+    """count_auth_sessions is None on pre-2.36.0 servers and must stay unknown."""
+    sensor = _sensor(
+        AudiobookShelfSensorEntityDescription(key="count_auth_sessions"),
+        {"count_auth_sessions": None},
+    )
+    assert sensor.native_value is None

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -1,0 +1,101 @@
+"""Tests for the guards on which items remove_my_progress matches."""
+
+import asyncio
+from collections.abc import AsyncIterator
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+import voluptuous as vol
+from aioaudiobookshelf.schema.library import LibraryItemMinifiedBook
+
+from custom_components.audiobookshelf.const import DOMAIN
+from custom_components.audiobookshelf.services import (
+    SERVICE_ATTRIBUTE_SERIES_NAME,
+    SERVICE_REMOVE_PROGRESS,
+    SERVICE_SCHEMAS,
+    async_setup_services,
+)
+
+SCHEMA = SERVICE_SCHEMAS[SERVICE_REMOVE_PROGRESS]
+
+
+def _book(item_id: str, series_name: str) -> Any:
+    """Build a stand-in book that satisfies the handler's isinstance check."""
+    book = MagicMock()
+    book.__class__ = LibraryItemMinifiedBook  # type: ignore[assignment]
+    book.id_ = item_id
+    book.media.metadata.series_name = series_name
+    book.media.metadata.title_ignore_prefix = item_id
+    return book
+
+
+def _removed_progress_for(books: list[Any], series_name: str) -> list[str]:
+    """Run the service over one library and return the progress ids it deleted."""
+
+    async def _get_library_items(library_id: str) -> AsyncIterator[Any]:  # noqa: ARG001
+        """Yield one page of results, then an empty page to end pagination."""
+        yield SimpleNamespace(results=books)
+        yield SimpleNamespace(results=[])
+
+    client = MagicMock()
+    client.get_all_libraries = AsyncMock(return_value=[SimpleNamespace(id_="lib-1")])
+    client.get_library_items = _get_library_items
+    client.get_my_media_progress = AsyncMock(
+        side_effect=lambda item_id: SimpleNamespace(id_=f"prog-{item_id}")
+    )
+    client.remove_my_media_progress = AsyncMock()
+
+    coordinator = MagicMock()
+    coordinator.get_client = AsyncMock(return_value=client)
+    coordinator.async_request_refresh = AsyncMock()
+
+    hass = MagicMock()
+    hass.data = {DOMAIN: coordinator}
+    async_setup_services(hass)
+    handler = hass.services.async_register.call_args.args[2]
+
+    call = SimpleNamespace(data=SCHEMA({SERVICE_ATTRIBUTE_SERIES_NAME: series_name}))
+    asyncio.run(handler(call))
+
+    return [
+        c.kwargs["media_progress_id"]
+        for c in client.remove_my_media_progress.call_args_list
+    ]
+
+
+@pytest.mark.parametrize("series_name", ["", "   ", "\t\n"])
+def test_blank_series_name_is_rejected(series_name: str) -> None:
+    """A blank name would substring-match every book, so it must not validate."""
+    with pytest.raises(vol.Invalid):
+        SCHEMA({SERVICE_ATTRIBUTE_SERIES_NAME: series_name})
+
+
+def test_missing_series_name_is_rejected() -> None:
+    """services.yaml marks the field required; the schema is what enforces it."""
+    with pytest.raises(vol.Invalid):
+        SCHEMA({})
+
+
+def test_surrounding_whitespace_is_stripped() -> None:
+    """A padded name matches the same items as an unpadded one."""
+    assert SCHEMA({SERVICE_ATTRIBUTE_SERIES_NAME: "  Dune  "}) == {
+        SERVICE_ATTRIBUTE_SERIES_NAME: "Dune"
+    }
+
+
+def test_only_matching_series_is_removed() -> None:
+    """Progress for unrelated series is left alone."""
+    books = [
+        _book("a", "The Expanse"),
+        _book("b", "The Witcher"),
+        _book("c", ""),
+    ]
+    assert _removed_progress_for(books, "Expanse") == ["prog-a"]
+
+
+def test_match_ignores_case() -> None:
+    """A lowercase name still matches a capitalised series."""
+    books = [_book("a", "The Expanse")]
+    assert _removed_progress_for(books, "expanse") == ["prog-a"]


### PR DESCRIPTION
Findings from a deep review pass. Every issue here is invisible to the
existing gates: ruff, mypy, pytest, hassfest and HACS validation all pass
on `main` today, and passed before and after these changes.

## Two paths that can destroy user data

**A second config entry silently deleted the first.** Every entry was
created with the same hardcoded unique id (`async_set_unique_id("Audiobookshelf")`),
so adding a second Audiobookshelf server matched the existing entry in
`async_finish_flow`. On HA 2025.1.4, which is the minimum `hacs.json`
declares, `config_entries.py:1479-1520` then unloads it, calls
`_async_remove`, and calls `_async_clean_up` on its devices and entities.
There is not even a deprecation log on that version.

This was reachable in normal use: with no reconfigure or options flow, the
natural way to change the server URL is to add it again.

Fixed by declaring `single_config_entry: true` so the flow aborts with
`single_instance_allowed` before reaching that path, and dropping the
hardcoded unique id. Existing entries keep their stored unique id, so no
migration is needed. Confirmed `single_config_entry` is honoured on
2025.1.4 (`loader.py:928`) and accepted by hassfest for custom
integrations (`CUSTOM_INTEGRATION_MANIFEST_SCHEMA` extends the base schema
that declares it).

**`remove_my_progress` could wipe all listening progress.** The service was
registered with no voluptuous schema, so `required: true` in
`services.yaml` was frontend metadata only and enforced nothing. Combined
with a bare substring test, an empty `series_name` matched every book
(`"" in anything` is `True`, and `seriesName` is `""` for standalone
books) and irreversibly deleted the API key owner's progress across every
library. A template rendering to an empty string was enough to trigger it.

Fixed by validating and stripping the field and rejecting anything blank.
Matching is now case-insensitive, so a lowercase name is no longer a
silent no-op. Added a `text` selector, without which the field did not
render in the UI at all, and replaced `default: true`, which set a boolean
default on a string field.

## Three silent failure modes

Each leaves the integration looking healthy while it has stopped working.

**A deleted library broke state updates for other entities.** A library
removed on the server drops out of `library_stats` while its entities live
on, so `native_value` raised `KeyError` inside the state write. That
escapes through `async_update_listeners`, which is unguarded and runs
outside the coordinator's try block, so every entity ordered after it
silently stopped updating. Because `last_update_success` was never set to
`False`, those entities kept reporting a stale value rather than going
unavailable, and it repeated every poll without self-healing.

**A transient error during setup stopped polling permanently.** The sensor
platform called `/api/libraries` a second time during setup, after the
first refresh had already fetched it. A failure there is swallowed by the
platform forward, leaving the entry `LOADED` with no entities, and since
the coordinator only schedules a refresh while it has listeners, polling
stopped for good. Now reuses the list the first refresh already fetched,
which removes both the extra request and the failure mode.

**Schema drift logged a traceback every poll.** Every `from_json` call
raises mashumaro's `MissingField` (a `LookupError`) or `InvalidFieldValue`
(a `ValueError`), and a non-JSON body raises `JSONDecodeError`. None are
`AbsError` or `ClientError`, so they escaped the handler entirely instead
of becoming a clean `UpdateFailed`. The new message names the method that
was in flight.

## Also

Every request is now bounded to 30 seconds. aiohttp defaults to five
minutes per request and a poll issues one per library plus five more, so a
server that accepts connections but stops responding could hold a poll
open far longer than the scan interval.

## Testing

20 new tests, all with plain pytest and `unittest.mock`. No new
dependencies: `pytest-homeassistant-custom-component` caps pytest at
<=8.3.4 and conflicts with the pinned 9.1.1, and nothing here needed it.

Each behavioural fix was checked with a negative control, reverting the
fix to confirm the test fails for the right reason before restoring it.
The four that guard the bugs above fail with a raw `KeyError`,
`JSONDecodeError` and mashumaro errors escaping, exactly as predicted.

- `tests/test_services.py` - blank and missing input rejected, only the
  matching series removed, case insensitivity
- `tests/test_sensor.py` - removed library, missing stat field, and that
  `count_auth_sessions` staying `None` on pre-2.36.0 servers is unaffected
- `tests/test_coordinator_errors.py` - the full exception mapping
  (`AbsAuthError` to `ConfigEntryAuthFailed`, other `AbsError` to
  `UpdateFailed`, `NotFoundError` not triggering reauth, the 2.36.0
  degrade) plus schema drift

All four checks from CLAUDE.md pass: ruff, ruff format, mypy on 12 files,
33 tests.

## Deliberately not in this PR

- The duplicate `/api/sessions/open` fetch per poll, which can also make
  `count_recent_sessions` exceed `count_open_sessions`. Fixing it cleanly
  means replacing the `getattr(self, method)()` loop with explicit calls.
- `entry.runtime_data` instead of the single `hass.data[DOMAIN]` slot,
  service registration in `async_setup`, `HomeAssistantError` wrapping,
  and the manifest `integration_type`/`loggers` corrections.
- Entity identity: `unique_id` and the device identifier both derive from
  the user-editable URL, so changing it orphans every entity. That one is
  breaking and needs a registry migration, so it wants its own release.
- CLAUDE.md states the release ZIP is what HACS installs. `hacs.json` sets
  no `zip_release`, so HACS pulls individual files from the tag and ignores
  the asset. Needs a follow-up now that #130 has merged.
