### PR TITLE
refactor: scope runtime data to the config entry and fix service lifecycle

### DIFF
--- a/custom_components/audiobookshelf/__init__.py
+++ b/custom_components/audiobookshelf/__init__.py
@@ -1,97 +1,73 @@
 """Custom component for Audiobookshelf."""
 
 import logging
+from collections.abc import Mapping
+from typing import Any
 
-import voluptuous as vol
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import (
-    CONF_API_KEY,
-    CONF_PASSWORD,
-    CONF_SCAN_INTERVAL,
-    CONF_URL,
-    CONF_USERNAME,
-)
+from homeassistant.const import CONF_API_KEY, CONF_SCAN_INTERVAL, CONF_URL
 from homeassistant.core import HomeAssistant
-from homeassistant.exceptions import ConfigEntryAuthFailed, ConfigEntryNotReady
 from homeassistant.helpers import config_validation as cv
-
-from custom_components.audiobookshelf.config_flow import validate_config, verify_config
+from homeassistant.helpers.typing import ConfigType
 
 from .audiobook_shelf_data_update_coordinator import AudiobookShelfDataUpdateCoordinator
 from .const import DOMAIN, PLATFORMS
-from .services import async_setup_services, async_unload_services
+from .services import async_setup_services
 
-CONFIG_SCHEMA = vol.Schema(
-    {
-        DOMAIN: vol.Schema(
-            {
-                vol.Required(CONF_USERNAME): cv.string,
-                vol.Required(CONF_PASSWORD): cv.string,
-                vol.Required(CONF_URL): cv.string,
-                vol.Optional(CONF_SCAN_INTERVAL, default=300): cv.positive_int,
-            }
-        )
-    },
-    extra=vol.ALLOW_EXTRA,
-)
+type AudiobookshelfConfigEntry = ConfigEntry[AudiobookShelfDataUpdateCoordinator]
+
+CONFIG_SCHEMA = cv.config_entry_only_config_schema(DOMAIN)
 
 _LOGGER = logging.getLogger(__name__)
 
 
-def clean_config(data: dict[str, str]) -> dict[str, str]:
-    """Remove the api key from config."""
-    try:
-        if CONF_API_KEY in data:
-            data[CONF_API_KEY] = "<redacted>"
-    except Exception as e:
-        _LOGGER.exception("Failed to clean config, most likely not valid", exc_info=e)
-    return data
+def clean_config(data: Mapping[str, Any]) -> dict[str, Any]:
+    """Return a copy of the config with the API key masked."""
+    # Builds a new mapping rather than editing in place: the previous version
+    # swallowed any exception and returned the argument untouched, so its
+    # failure mode was to log the credential it exists to hide.
+    return {
+        key: "<redacted>" if key == CONF_API_KEY else value
+        for key, value in data.items()
+    }
 
 
-async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:  # noqa: ARG001
+    """Register the Audiobookshelf services."""
+    # Registering here rather than per entry keeps the actions resolvable
+    # while the entry is unloaded or failed, so automations referencing them
+    # still validate instead of failing with an unknown service.
+    async_setup_services(hass)
+    return True
+
+
+async def async_setup_entry(
+    hass: HomeAssistant, entry: AudiobookshelfConfigEntry
+) -> bool:
     """Set up Audiobookshelf from a config entry."""
-    hass.data.setdefault(DOMAIN, {})
+    _LOGGER.debug("Setting up Audiobookshelf with config: %s", clean_config(entry.data))
 
-    if entry.data is None:
-        error_message = "Configuration not found"
-        raise ConfigEntryNotReady(error_message)
-
-    _LOGGER.debug(
-        "Setting up Audiobookshelf with config: %s", clean_config(entry.data.copy())
-    )
-
-    errors = validate_config(entry.data.copy())
-    errors.update(await verify_config(entry.data.copy()))
-    if len(errors.keys()) > 0:
-        _LOGGER.debug("Config validation errors: %s", errors)
-        if errors.get("base") in ("api_auth_error", "not_admin"):
-            raise ConfigEntryAuthFailed(errors)
-        raise ConfigEntryNotReady(errors)
-
-    scan_interval = int(entry.data[CONF_SCAN_INTERVAL])
-    api_url = entry.data[CONF_URL]
-    token = entry.data[CONF_API_KEY]
     coordinator = AudiobookShelfDataUpdateCoordinator(
         hass,
         config_entry=entry,
-        scan_interval=scan_interval,
-        api_url=api_url,
-        token=token,
+        scan_interval=int(entry.data[CONF_SCAN_INTERVAL]),
+        api_url=entry.data[CONF_URL],
+        token=entry.data[CONF_API_KEY],
     )
 
+    # This doubles as the setup-time connection test, raising
+    # ConfigEntryNotReady or ConfigEntryAuthFailed as appropriate, so no
+    # separate probe over its own session is needed.
     await coordinator.async_config_entry_first_refresh()
 
-    hass.data[DOMAIN] = coordinator
+    entry.runtime_data = coordinator
 
-    async_setup_services(hass)
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
     return True
 
 
-async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+async def async_unload_entry(
+    hass: HomeAssistant, entry: AudiobookshelfConfigEntry
+) -> bool:
     """Unload a config entry."""
-    unload_ok = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
-    if unload_ok:
-        async_unload_services(hass)
-        hass.data.pop(DOMAIN, None)
-    return unload_ok
+    return await hass.config_entries.async_unload_platforms(entry, PLATFORMS)

--- a/custom_components/audiobookshelf/audiobook_shelf_data_update_coordinator.py
+++ b/custom_components/audiobookshelf/audiobook_shelf_data_update_coordinator.py
@@ -11,7 +11,12 @@ from aioaudiobookshelf import (
     SessionConfiguration,
     get_admin_client_by_token,
 )
-from aioaudiobookshelf.exceptions import AbsAuthError, AbsError, NotFoundError
+from aioaudiobookshelf.exceptions import (
+    AbsAuthError,
+    AbsError,
+    BadUserError,
+    NotFoundError,
+)
 from aioaudiobookshelf.schema import _BaseModel
 from aioaudiobookshelf.schema.library import Library
 from aioaudiobookshelf.schema.session import PlaybackSession
@@ -27,15 +32,6 @@ from mashumaro.types import Alias
 from .const import REQUEST_TIMEOUT
 
 _LOGGER = getLogger(__name__)
-
-API_DATA_METHODS = [
-    "count_users",
-    "count_users_online",
-    "count_open_sessions",
-    "count_recent_sessions",
-    "count_auth_sessions",
-    "library_stats",
-]
 
 
 @dataclass(kw_only=True)
@@ -145,19 +141,14 @@ class AudiobookShelfDataUpdateCoordinator(DataUpdateCoordinator):
         users = response_cls.from_json(response).users
         return len(users)
 
-    async def count_recent_sessions(self) -> int:
-        """Fetch and count open sessions with recent update time from API."""
+    async def open_sessions(self) -> OpenSessionsResponse:
+        """Fetch open sessions from API."""
+        # Fetched once per poll and used for both the open and recent counts.
+        # Fetching twice made it possible for a session ending between the two
+        # calls to report more recent sessions than open ones.
         client = await self.get_client()
         response = await client._get("api/sessions/open")  # noqa: SLF001
-        sessions = OpenSessionsResponse.from_json(response).filter_active_sessions()
-        return len(sessions)
-
-    async def count_open_sessions(self) -> int:
-        """Fetch and count open sessions from API."""
-        client = await self.get_client()
-        response = await client._get("api/sessions/open")  # noqa: SLF001
-        sessions = OpenSessionsResponse.from_json(response).sessions
-        return len(sessions)
+        return OpenSessionsResponse.from_json(response)
 
     async def count_auth_sessions(self) -> int | None:
         """Fetch and count auth sessions from API, None if server lacks endpoint."""
@@ -190,19 +181,25 @@ class AudiobookShelfDataUpdateCoordinator(DataUpdateCoordinator):
 
     async def _async_update_data(self) -> dict:
         """Fetch data from API endpoint."""
-        data = {}
-        method = ""
+        step = "users"
         try:
-            for method in API_DATA_METHODS:
-                _LOGGER.debug("Fetched %s", method)
-                data[method] = await getattr(self, method)()
-                _LOGGER.debug("Fetched %s", data[method])
-            data["count_libraries"] = len(data["library_stats"].keys())
+            count_users = await self.count_users()
+            step = "users online"
+            count_users_online = await self.count_users_online()
+            step = "open sessions"
+            open_sessions = await self.open_sessions()
+            step = "auth sessions"
+            count_auth_sessions = await self.count_auth_sessions()
+            step = "library stats"
+            library_stats = await self.library_stats()
+        except BadUserError as err:
+            msg = "The Audiobookshelf API key must belong to an admin user"
+            raise ConfigEntryAuthFailed(msg) from err
         except AbsAuthError as err:
             msg = "Authentication with Audiobookshelf failed"
             raise ConfigEntryAuthFailed(msg) from err
         except (AbsError, ClientError) as err:
-            msg = "Error fetching data"
+            msg = f"Error fetching {step} from Audiobookshelf"
             raise UpdateFailed(msg) from err
         except (ValueError, LookupError) as err:
             # Every from_json call raises mashumaro's MissingField (LookupError)
@@ -210,7 +207,17 @@ class AudiobookShelfDataUpdateCoordinator(DataUpdateCoordinator):
             # body raises JSONDecodeError (ValueError). None of these are
             # AbsError or ClientError, so without this they escape as an
             # unhandled exception and log a traceback on every poll.
-            msg = f"Unexpected response from Audiobookshelf fetching {method}"
+            msg = f"Unexpected response from Audiobookshelf fetching {step}"
             raise UpdateFailed(msg) from err
         else:
+            data = {
+                "count_users": count_users,
+                "count_users_online": count_users_online,
+                "count_open_sessions": len(open_sessions.sessions),
+                "count_recent_sessions": len(open_sessions.filter_active_sessions()),
+                "count_auth_sessions": count_auth_sessions,
+                "library_stats": library_stats,
+                "count_libraries": len(library_stats),
+            }
+            _LOGGER.debug("Fetched Audiobookshelf data: %s", data)
             return data

--- a/custom_components/audiobookshelf/config_flow.py
+++ b/custom_components/audiobookshelf/config_flow.py
@@ -8,15 +8,17 @@ from typing import TYPE_CHECKING, Any
 import homeassistant.helpers.config_validation as cv
 import voluptuous as vol
 from aioaudiobookshelf import SessionConfiguration, get_admin_client_by_token
-from aioaudiobookshelf.exceptions import AbsAuthError, BadUserError
-from aiohttp import ClientError, ClientSession
+from aioaudiobookshelf.exceptions import AbsAuthError, AbsError, BadUserError
+from aiohttp import ClientError
 from homeassistant import config_entries
 from homeassistant.const import CONF_API_KEY, CONF_SCAN_INTERVAL, CONF_URL
+from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
 if TYPE_CHECKING:
     from collections.abc import Mapping
 
     from homeassistant.config_entries import ConfigFlowResult
+    from homeassistant.core import HomeAssistant
 
 from .const import DOMAIN, REQUEST_TIMEOUT
 
@@ -37,25 +39,33 @@ def validate_config(data: dict[str, Any]) -> dict:
     return errors
 
 
-async def verify_config(data: dict[str, str]) -> dict:
+async def verify_config(hass: HomeAssistant, data: dict[str, str]) -> dict:
     """Verify the configuration by testing the API connection."""
     try:
-        async with ClientSession() as session:
-            await get_admin_client_by_token(
-                session_config=SessionConfiguration(
-                    session=session,
-                    url=data[CONF_URL],
-                    token=data[CONF_API_KEY],
-                    logger=_LOGGER,
-                    pagination_items_per_page=30,
-                    timeout=REQUEST_TIMEOUT,
-                ),
-            )
+        await get_admin_client_by_token(
+            session_config=SessionConfiguration(
+                session=async_get_clientsession(hass),
+                url=data[CONF_URL],
+                token=data[CONF_API_KEY],
+                logger=_LOGGER,
+                pagination_items_per_page=30,
+                timeout=REQUEST_TIMEOUT,
+            ),
+        )
     except BadUserError:
+        # A subclass of AbsAuthError, so this clause has to come first.
         return {"base": "not_admin"}
     except AbsAuthError:
         return {"base": "api_auth_error"}
-    except (ClientError, TimeoutError):
+    except (AbsError, ClientError, TimeoutError):
+        # AbsError covers the case of a URL that resolves but is not an
+        # Audiobookshelf server, which otherwise escaped the flow and showed
+        # the user "Unknown error occurred".
+        return {"base": "cannot_connect"}
+    except (ValueError, LookupError):
+        # A login response that is not the expected JSON, which is what a
+        # captive portal or SSO page in front of the server returns.
+        _LOGGER.exception("Unexpected response from %s", data[CONF_URL])
         return {"base": "cannot_connect"}
     else:
         return {}
@@ -75,7 +85,7 @@ class AudiobookshelfConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         if user_input is not None:
             errors.update(validate_config(user_input))
             if not errors:
-                errors.update(await verify_config(user_input))
+                errors.update(await verify_config(self.hass, user_input))
             if errors:
                 return self.async_show_form(
                     step_id="user",
@@ -134,7 +144,8 @@ class AudiobookshelfConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
         if user_input is not None:
             errors = await verify_config(
-                {**reauth_entry.data, CONF_API_KEY: user_input[CONF_API_KEY]}
+                self.hass,
+                {**reauth_entry.data, CONF_API_KEY: user_input[CONF_API_KEY]},
             )
             if not errors:
                 return self.async_update_reload_and_abort(

--- a/custom_components/audiobookshelf/manifest.json
+++ b/custom_components/audiobookshelf/manifest.json
@@ -7,9 +7,12 @@
   "config_flow": true,
   "dependencies": [],
   "documentation": "https://github.com/wolffshots/hass-audiobookshelf",
-  "integration_type": "device",
+  "integration_type": "service",
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/wolffshots/hass-audiobookshelf/issues",
+  "loggers": [
+    "aioaudiobookshelf"
+  ],
   "requirements": [
     "aioaudiobookshelf"
   ],

--- a/custom_components/audiobookshelf/sensor.py
+++ b/custom_components/audiobookshelf/sensor.py
@@ -10,20 +10,23 @@ from homeassistant.components.sensor import (
     SensorEntityDescription,
     SensorStateClass,
 )
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import UnitOfInformation
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from custom_components.audiobookshelf import clean_config
+from custom_components.audiobookshelf import AudiobookshelfConfigEntry, clean_config
 from custom_components.audiobookshelf.audiobook_shelf_data_update_coordinator import (
     AudiobookShelfDataUpdateCoordinator,
 )
 from custom_components.audiobookshelf.const import DOMAIN, VERSION
 
 _LOGGER = getLogger(__name__)
+
+# Read-only platform: nothing here writes to the server, so there is no reason
+# to serialise updates.
+PARALLEL_UPDATES = 0
 
 
 @dataclass(frozen=True)
@@ -81,14 +84,14 @@ SENSOR_DESCRIPTIONS: Final[tuple[AudiobookShelfSensorEntityDescription, ...]] = 
 
 
 async def async_setup_entry(
-    hass: HomeAssistant,
-    entry: ConfigEntry,
+    hass: HomeAssistant,  # noqa: ARG001
+    entry: AudiobookshelfConfigEntry,
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up the sensor platform."""
-    _LOGGER.debug("Configuration data: %s", clean_config(entry.data.copy()))
+    _LOGGER.debug("Configuration data: %s", clean_config(entry.data))
 
-    coordinator: AudiobookShelfDataUpdateCoordinator = hass.data[DOMAIN]
+    coordinator = entry.runtime_data
 
     sensors_descriptions: list[AudiobookShelfSensorEntityDescription] = []
     sensors_descriptions.extend(SENSOR_DESCRIPTIONS)

--- a/custom_components/audiobookshelf/services.py
+++ b/custom_components/audiobookshelf/services.py
@@ -1,20 +1,18 @@
 """Module containing the services platform for the Audiobookshelf integration."""
 
 from logging import getLogger
-from typing import TYPE_CHECKING
+from typing import cast
 
 import homeassistant.helpers.config_validation as cv
 import voluptuous as vol
-from aioaudiobookshelf.schema.library import (
-    LibraryItemMinifiedBook,
-    LibraryItemMinifiedPodcast,
-)
-from homeassistant.core import HomeAssistant, ServiceCall, callback
+from aioaudiobookshelf.exceptions import AbsError
+from aioaudiobookshelf.schema.library import LibraryItemMinifiedBook
+from homeassistant.config_entries import ConfigEntryState
+from homeassistant.core import HomeAssistant, ServiceCall
+from homeassistant.exceptions import HomeAssistantError, ServiceValidationError
 
+from .audiobook_shelf_data_update_coordinator import AudiobookShelfDataUpdateCoordinator
 from .const import DOMAIN
-
-if TYPE_CHECKING:
-    from . import AudiobookShelfDataUpdateCoordinator
 
 SERVICE_REMOVE_PROGRESS = "remove_my_progress"
 
@@ -41,49 +39,58 @@ _LOGGER = getLogger(__name__)
 def async_setup_services(hass: HomeAssistant) -> bool:
     """Set up the Audiobookshelf services."""
 
+    def loaded_coordinator() -> AudiobookShelfDataUpdateCoordinator:
+        """Return the coordinator, or explain why the action cannot run."""
+        entries = hass.config_entries.async_entries(DOMAIN)
+        if not entries:
+            msg = "Audiobookshelf is not configured"
+            raise ServiceValidationError(msg)
+        if entries[0].state is not ConfigEntryState.LOADED:
+            msg = "The Audiobookshelf configuration entry is not loaded"
+            raise ServiceValidationError(msg)
+        return cast("AudiobookShelfDataUpdateCoordinator", entries[0].runtime_data)
+
     async def async_handle_remove_progress(call: ServiceCall) -> None:
         """Handle the remove progress service call."""
-        coordinator: AudiobookShelfDataUpdateCoordinator = hass.data[DOMAIN]
+        coordinator = loaded_coordinator()
         series_name: str = call.data[SERVICE_ATTRIBUTE_SERIES_NAME].casefold()
+        removed = 0
 
-        client = await coordinator.get_client()
-        libraries = await client.get_all_libraries()
         _LOGGER.debug("Searching for %s", series_name)
-        for library in libraries:
-            async for response in client.get_library_items(library_id=library.id_):
-                if not response.results:
-                    break
-                for lib_item_minified in response.results:
-                    if isinstance(lib_item_minified, LibraryItemMinifiedPodcast):
-                        pass
-                    if isinstance(lib_item_minified, LibraryItemMinifiedBook):
-                        item_series_name = lib_item_minified.media.metadata.series_name
+        try:
+            client = await coordinator.get_client()
+            for library in await client.get_all_libraries():
+                async for response in client.get_library_items(library_id=library.id_):
+                    if not response.results:
+                        break
+                    for item in response.results:
+                        if not isinstance(item, LibraryItemMinifiedBook):
+                            continue
+                        item_series_name = item.media.metadata.series_name
                         if (
-                            isinstance(item_series_name, str)
-                            and series_name in item_series_name.casefold()
+                            not isinstance(item_series_name, str)
+                            or series_name not in item_series_name.casefold()
                         ):
-                            media_progress = await client.get_my_media_progress(
-                                item_id=lib_item_minified.id_
-                            )
-                            _LOGGER.debug(
-                                "found match of %s",
-                                lib_item_minified.media.metadata.title_ignore_prefix,
-                            )
-                            if media_progress is not None:
-                                _LOGGER.debug(
-                                    "deleting media progress for %s",
-                                    lib_item_minified.media.metadata.title_ignore_prefix,
-                                )
-                                await client.remove_my_media_progress(
-                                    media_progress_id=media_progress.id_
-                                )
-                        else:
-                            _LOGGER.debug(
-                                "not found match of %s",
-                                lib_item_minified.media.metadata.title_ignore_prefix,
-                            )
-
-        await coordinator.async_request_refresh()
+                            continue
+                        progress = await client.get_my_media_progress(item_id=item.id_)
+                        if progress is None:
+                            continue
+                        _LOGGER.debug(
+                            "Removing progress for %s",
+                            item.media.metadata.title_ignore_prefix,
+                        )
+                        await client.remove_my_media_progress(
+                            media_progress_id=progress.id_
+                        )
+                        removed += 1
+        except AbsError as err:
+            # Deletions already made cannot be rolled back, so say how far it
+            # got rather than reporting a bare failure.
+            msg = f"Removing progress failed after {removed} item(s): {err}"
+            raise HomeAssistantError(msg) from err
+        finally:
+            _LOGGER.debug("Removed progress for %s item(s)", removed)
+            await coordinator.async_request_refresh()
 
     services = {
         SERVICE_REMOVE_PROGRESS: async_handle_remove_progress,
@@ -94,10 +101,3 @@ def async_setup_services(hass: HomeAssistant) -> bool:
         )
 
     return True
-
-
-@callback
-def async_unload_services(hass: HomeAssistant) -> None:
-    """Unload the Audiobookshelf services from hass."""
-    for service in SUPPORTED_SERVICES:
-        hass.services.async_remove(DOMAIN, service)

--- a/tests/test_coordinator_errors.py
+++ b/tests/test_coordinator_errors.py
@@ -126,5 +126,5 @@ def test_auth_sessions_degrade_to_none_on_404() -> None:
 def test_schema_drift_is_update_failed(body: bytes) -> None:
     """Parse failures are neither AbsError nor ClientError and must be caught."""
     coordinator = _with_client(_endpoints(**{"api/libraries/lib-1/stats": body}))
-    with pytest.raises(UpdateFailed, match="library_stats"):
+    with pytest.raises(UpdateFailed, match="library stats"):
         asyncio.run(coordinator._async_update_data())  # noqa: SLF001

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -8,9 +8,11 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 import voluptuous as vol
+from aioaudiobookshelf.exceptions import ApiError
 from aioaudiobookshelf.schema.library import LibraryItemMinifiedBook
+from homeassistant.config_entries import ConfigEntryState
+from homeassistant.exceptions import HomeAssistantError, ServiceValidationError
 
-from custom_components.audiobookshelf.const import DOMAIN
 from custom_components.audiobookshelf.services import (
     SERVICE_ATTRIBUTE_SERIES_NAME,
     SERVICE_REMOVE_PROGRESS,
@@ -31,8 +33,8 @@ def _book(item_id: str, series_name: str) -> Any:
     return book
 
 
-def _removed_progress_for(books: list[Any], series_name: str) -> list[str]:
-    """Run the service over one library and return the progress ids it deleted."""
+def _client(books: list[Any], remove_error: Exception | None = None) -> MagicMock:
+    """Build a client serving one library of the given books."""
 
     async def _get_library_items(library_id: str) -> AsyncIterator[Any]:  # noqa: ARG001
         """Yield one page of results, then an empty page to end pagination."""
@@ -45,20 +47,37 @@ def _removed_progress_for(books: list[Any], series_name: str) -> list[str]:
     client.get_my_media_progress = AsyncMock(
         side_effect=lambda item_id: SimpleNamespace(id_=f"prog-{item_id}")
     )
-    client.remove_my_media_progress = AsyncMock()
+    client.remove_my_media_progress = AsyncMock(side_effect=remove_error)
+    return client
 
+
+def _hass(client: MagicMock, state: ConfigEntryState = ConfigEntryState.LOADED) -> Any:
+    """Build a hass stub holding a single config entry in the given state."""
     coordinator = MagicMock()
     coordinator.get_client = AsyncMock(return_value=client)
     coordinator.async_request_refresh = AsyncMock()
 
+    entry = MagicMock()
+    entry.state = state
+    entry.runtime_data = coordinator
+
     hass = MagicMock()
-    hass.data = {DOMAIN: coordinator}
+    hass.config_entries.async_entries.return_value = [entry]
+    return hass
+
+
+def _call(hass: Any, series_name: str) -> None:
+    """Register the services and invoke remove_my_progress on the stub."""
     async_setup_services(hass)
     handler = hass.services.async_register.call_args.args[2]
-
     call = SimpleNamespace(data=SCHEMA({SERVICE_ATTRIBUTE_SERIES_NAME: series_name}))
     asyncio.run(handler(call))
 
+
+def _removed_progress_for(books: list[Any], series_name: str) -> list[str]:
+    """Run the service over one library and return the progress ids it deleted."""
+    client = _client(books)
+    _call(_hass(client), series_name)
     return [
         c.kwargs["media_progress_id"]
         for c in client.remove_my_media_progress.call_args_list
@@ -99,3 +118,37 @@ def test_match_ignores_case() -> None:
     """A lowercase name still matches a capitalised series."""
     books = [_book("a", "The Expanse")]
     assert _removed_progress_for(books, "expanse") == ["prog-a"]
+
+
+def test_unconfigured_integration_is_reported() -> None:
+    """The action exists even with no entry, so it has to explain itself."""
+    hass = _hass(_client([]))
+    hass.config_entries.async_entries.return_value = []
+    with pytest.raises(ServiceValidationError):
+        _call(hass, "Expanse")
+
+
+def test_unloaded_entry_is_reported() -> None:
+    """An entry that failed to load has no coordinator to work with."""
+    hass = _hass(_client([]), state=ConfigEntryState.SETUP_ERROR)
+    with pytest.raises(ServiceValidationError):
+        _call(hass, "Expanse")
+
+
+def test_api_failure_reports_how_far_it_got() -> None:
+    """Deletions cannot be rolled back, so the count so far has to surface."""
+    books = [_book("a", "The Expanse"), _book("b", "The Expanse")]
+    hass = _hass(_client(books, remove_error=ApiError("server went away")))
+    with pytest.raises(HomeAssistantError, match="after 0 item"):
+        _call(hass, "Expanse")
+
+
+def test_refresh_is_requested_even_when_the_run_fails() -> None:
+    """A partial run still changed state, so the sensors must be refreshed."""
+    hass = _hass(
+        _client([_book("a", "The Expanse")], remove_error=ApiError("boom")),
+    )
+    coordinator = hass.config_entries.async_entries.return_value[0].runtime_data
+    with pytest.raises(HomeAssistantError):
+        _call(hass, "Expanse")
+    assert coordinator.async_request_refresh.await_count == 1


### PR DESCRIPTION
Follows #131, which has now merged; this was retargeted from its branch
to main.

Hassfest and HACS validation do not run on this PR: `hacs.yml` triggers
only on pull requests targeting `main`, and retargeting an open PR fires
an `edited` event, which is not a default workflow trigger. Both were run
against the branch manually via `workflow_dispatch` and pass, which
matters here because this changes `manifest.json` and adds `async_setup`,
the latter activating hassfest's `config_schema` plugin for the first
time.

Second pass from the review. #131 fixed what was actively breaking; this
fixes the shape underneath it.

## Runtime data and service lifecycle

The coordinator lived in a single `hass.data[DOMAIN]` slot, written as
`hass.data[DOMAIN] = coordinator` over a dict created by `setdefault` two
lines earlier. Unloading any entry popped the whole key and deregistered
the services. Now on `entry.runtime_data`, which Home Assistant clears on
unload, so `async_unload_entry` is one line.

Services move from `async_setup_entry` to `async_setup`. Registering them
per entry meant unloading the entry removed `remove_my_progress` from the
registry entirely, so an automation referencing it failed validation with
an unknown service rather than a useful message. The handler resolves the
entry itself and raises `ServiceValidationError` when there is none or it
is not loaded, replacing a bare `KeyError` into the automation engine.

The sweep is wrapped: an `AbsError` mid-run now becomes a
`HomeAssistantError` stating how many items were already deleted, since
those deletions cannot be rolled back and the user previously got a bare
traceback with no indication of what had been affected. The refresh moved
into a `finally`, so a partial run still updates the sensors.

Note there is deliberately no `config_entry_id` field, which the
`action-setup` pattern would normally add. That would break every existing
automation, and #131 declares `single_config_entry: true`, so the handler
can just resolve the one entry.

## Setup

Dropped the `verify_config` probe from `async_setup_entry`.
`async_config_entry_first_refresh` already satisfies test-before-setup, and
the probe duplicated the request on every restart and reload over its own
`ClientSession`, then passed a dict to `ConfigEntryAuthFailed` where Home
Assistant expects a message string, so the UI rendered
`{'base': 'api_auth_error'}`. Not-admin is now reported by the coordinator
catching `BadUserError` ahead of `AbsAuthError`, with a message that says
so.

`CONFIG_SCHEMA` declared required `username` and `password` for an
integration that authenticates by API key and has no `async_setup` to
consume them. Replaced with `cv.config_entry_only_config_schema`.

`clean_config` caught every exception and returned its argument unchanged,
so its failure mode was to return the credential it exists to mask. Both
call sites happened to pass a copy, which is what kept it safe. It now
builds a new mapping and cannot fail open.

## Coordinator

`/api/sessions/open` was fetched twice per poll, by two methods that each
parsed the full `PlaybackSession` model. Besides the wasted request, a
session ending between the two calls could report more recent sessions
than open ones, which is impossible by definition. Fetched once now.

Replacing the `getattr(self, method)()` reflection loop with explicit calls
also lets a failure name the step it was on, so `UpdateFailed` says which
endpoint drifted instead of just "Error fetching data".

## Config flow

`verify_config` built its own `ClientSession` per validation instead of the
shared one the coordinator already used correctly.

It caught only `AbsAuthError`, `ClientError` and `TimeoutError`. A URL that
resolves but is not an Audiobookshelf server raises `NotFoundError`, an
`AbsError` but not an `AbsAuthError`, so it escaped the flow and showed
"Unknown error occurred" with no hint the URL was wrong. A login response
that is not JSON, which is what a captive portal or SSO page in front of
the server returns, escaped the same way.

## Manifest

`integration_type` was `device`; the manifest docs reserve that for a
single physical device and specify `service` for a self-hosted server like
this. Added `loggers` so users can raise the `aioaudiobookshelf` log level
from the integration's own controls.

## Testing

37 tests, 4 new, covering the unconfigured and unloaded entry paths, the
partial-failure message, and that the refresh still runs when the sweep
fails. ruff, ruff format, mypy and pytest all clean.

## Not included

The `aioaudiobookshelf` requirement is still unpinned. Bounding it to
`<0.2` is worth doing given the six `client._get` call sites and CLAUDE.md's
own note that `_get`'s 404 behaviour already changed once across versions.
But it is a maintenance policy change that contradicts CLAUDE.md's "users
always get the newest" note, so it belongs with the docs update rather than
landing silently here.

Still outstanding after this: entity identity (`unique_id` and the device
identifier both derive from the user-editable URL, so changing it orphans
every entity), which is breaking and needs a registry migration;
`has_entity_name` and entity translations; dynamic library discovery; and
the CI hardening.

