### PR TITLE
feat!: key entity and device identity on the config entry

### DIFF
--- a/custom_components/audiobookshelf/__init__.py
+++ b/custom_components/audiobookshelf/__init__.py
@@ -6,8 +6,10 @@ from typing import Any
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_API_KEY, CONF_SCAN_INTERVAL, CONF_URL
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers import config_validation as cv
+from homeassistant.helpers import device_registry as dr
+from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.typing import ConfigType
 
 from .audiobook_shelf_data_update_coordinator import AudiobookShelfDataUpdateCoordinator
@@ -30,6 +32,46 @@ def clean_config(data: Mapping[str, Any]) -> dict[str, Any]:
         key: "<redacted>" if key == CONF_API_KEY else value
         for key, value in data.items()
     }
+
+
+@callback
+def _migrate_url_identifiers(hass: HomeAssistant, entry: ConfigEntry) -> None:
+    """Re-key entities and the device from the API URL onto the entry id."""
+    # v1 built both from the URL, which the user can edit, so moving the
+    # server orphaned every entity and created a second device. Rewriting
+    # them here preserves history, dashboards and any area assignment.
+    old_prefix = f"{entry.data[CONF_URL]}_"
+
+    entity_registry = er.async_get(hass)
+    for registry_entry in er.async_entries_for_config_entry(
+        entity_registry, entry.entry_id
+    ):
+        if not registry_entry.unique_id.startswith(old_prefix):
+            continue
+        suffix = registry_entry.unique_id.removeprefix(old_prefix)
+        entity_registry.async_update_entity(
+            registry_entry.entity_id,
+            new_unique_id=f"{entry.entry_id}_{suffix}",
+        )
+
+    device_registry = dr.async_get(hass)
+    device = device_registry.async_get_device(
+        identifiers={(DOMAIN, entry.data[CONF_URL])}
+    )
+    if device is not None:
+        device_registry.async_update_device(
+            device.id, new_identifiers={(DOMAIN, entry.entry_id)}
+        )
+
+
+async def async_migrate_entry(
+    hass: HomeAssistant, entry: AudiobookshelfConfigEntry
+) -> bool:
+    """Migrate an old config entry."""
+    if entry.version == 1:
+        _migrate_url_identifiers(hass, entry)
+        hass.config_entries.async_update_entry(entry, version=2)
+    return True
 
 
 async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:  # noqa: ARG001

--- a/custom_components/audiobookshelf/config_flow.py
+++ b/custom_components/audiobookshelf/config_flow.py
@@ -74,7 +74,9 @@ async def verify_config(hass: HomeAssistant, data: dict[str, str]) -> dict:
 class AudiobookshelfConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     """Handle a config flow for Audiobookshelf."""
 
-    VERSION = 1
+    # Bumped to 2 when entity and device identifiers moved off the API URL
+    # onto the entry id. See async_migrate_entry.
+    VERSION = 2
 
     async def async_step_user(
         self, user_input: dict[str, str] | None = None

--- a/custom_components/audiobookshelf/sensor.py
+++ b/custom_components/audiobookshelf/sensor.py
@@ -12,7 +12,7 @@ from homeassistant.components.sensor import (
 )
 from homeassistant.const import UnitOfInformation
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers.device_registry import DeviceInfo
+from homeassistant.helpers.device_registry import DeviceEntryType, DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
@@ -20,7 +20,7 @@ from custom_components.audiobookshelf import AudiobookshelfConfigEntry, clean_co
 from custom_components.audiobookshelf.audiobook_shelf_data_update_coordinator import (
     AudiobookShelfDataUpdateCoordinator,
 )
-from custom_components.audiobookshelf.const import DOMAIN, VERSION
+from custom_components.audiobookshelf.const import DOMAIN
 
 _LOGGER = getLogger(__name__)
 
@@ -40,42 +40,42 @@ class AudiobookShelfSensorEntityDescription(SensorEntityDescription):
 SENSOR_DESCRIPTIONS: Final[tuple[AudiobookShelfSensorEntityDescription, ...]] = (
     AudiobookShelfSensorEntityDescription(
         key="count_users",
-        name="Audiobookshelf Users",
+        translation_key="count_users",
         icon="mdi:account-multiple-outline",
         state_class=SensorStateClass.MEASUREMENT,
         native_unit_of_measurement="users",
     ),
     AudiobookShelfSensorEntityDescription(
         key="count_users_online",
-        name="Audiobookshelf Users Online",
+        translation_key="count_users_online",
         icon="mdi:account-multiple",
         state_class=SensorStateClass.MEASUREMENT,
         native_unit_of_measurement="users",
     ),
     AudiobookShelfSensorEntityDescription(
         key="count_open_sessions",
-        name="Audiobookshelf Open Sessions",
+        translation_key="count_open_sessions",
         icon="mdi:account-music-outline",
         state_class=SensorStateClass.MEASUREMENT,
         native_unit_of_measurement="sessions",
     ),
     AudiobookShelfSensorEntityDescription(
         key="count_recent_sessions",
-        name="Audiobookshelf Recent Sessions",
+        translation_key="count_recent_sessions",
         icon="mdi:account-music",
         state_class=SensorStateClass.MEASUREMENT,
         native_unit_of_measurement="sessions",
     ),
     AudiobookShelfSensorEntityDescription(
         key="count_auth_sessions",
-        name="Audiobookshelf Auth Sessions",
+        translation_key="count_auth_sessions",
         icon="mdi:shield-account-outline",
         state_class=SensorStateClass.MEASUREMENT,
         native_unit_of_measurement="sessions",
     ),
     AudiobookShelfSensorEntityDescription(
         key="count_libraries",
-        name="Audiobookshelf Libraries",
+        translation_key="count_libraries",
         icon="mdi:bookshelf",
         state_class=SensorStateClass.MEASUREMENT,
         native_unit_of_measurement="libraries",
@@ -107,7 +107,8 @@ async def async_setup_entry(
                     key="library_stats",
                     key_context=library.id_,
                     key_context_method="total_size",
-                    name=f"Audiobookshelf {library.name} Size",
+                    translation_key="library_size",
+                    translation_placeholders={"library": library.name},
                     icon="mdi:harddisk",
                     device_class=SensorDeviceClass.DATA_SIZE,
                     state_class=SensorStateClass.MEASUREMENT,
@@ -119,7 +120,8 @@ async def async_setup_entry(
                     key="library_stats",
                     key_context=library.id_,
                     key_context_method="total_items",
-                    name=f"Audiobookshelf {library.name} Items",
+                    translation_key="library_items",
+                    translation_placeholders={"library": library.name},
                     icon="mdi:book-multiple",
                     state_class=SensorStateClass.MEASUREMENT,
                     native_unit_of_measurement="items",
@@ -128,7 +130,8 @@ async def async_setup_entry(
                     key="library_stats",
                     key_context=library.id_,
                     key_context_method="total_duration",
-                    name=f"Audiobookshelf {library.name} Duration",
+                    translation_key="library_duration",
+                    translation_placeholders={"library": library.name},
                     icon="mdi:timer-outline",
                     device_class=SensorDeviceClass.DURATION,
                     state_class=SensorStateClass.MEASUREMENT,
@@ -139,7 +142,7 @@ async def async_setup_entry(
             ]
         )
     entities = [
-        AudiobookShelfSensor(coordinator, sensor_description)
+        AudiobookShelfSensor(coordinator, entry, sensor_description)
         for sensor_description in sensors_descriptions
     ]
     async_add_entities(entities)
@@ -149,10 +152,12 @@ class AudiobookShelfSensor(CoordinatorEntity, SensorEntity):
     """Representation of a sensor."""
 
     coordinator: AudiobookShelfDataUpdateCoordinator
+    _attr_has_entity_name = True
 
     def __init__(
         self,
         coordinator: AudiobookShelfDataUpdateCoordinator,
+        entry: AudiobookshelfConfigEntry,
         sensor_description: AudiobookShelfSensorEntityDescription,
     ) -> None:
         """Initialize the sensor."""
@@ -160,6 +165,20 @@ class AudiobookShelfSensor(CoordinatorEntity, SensorEntity):
             sensor_description
         )
         super().__init__(coordinator, None)
+        # Keyed on the entry id rather than the API URL, which the user can
+        # edit. Any change to this format needs a matching async_migrate_entry.
+        self._attr_unique_id = (
+            f"{entry.entry_id}_{sensor_description.key}"
+            f"_{sensor_description.key_context}"
+            f"_{sensor_description.key_context_method}"
+        )
+        self._attr_device_info = DeviceInfo(
+            identifiers={(DOMAIN, entry.entry_id)},
+            entry_type=DeviceEntryType.SERVICE,
+            name="Audiobookshelf",
+            manufacturer="advplyr",
+            configuration_url=coordinator.api_url,
+        )
 
     @property
     def available(self) -> bool:
@@ -187,24 +206,3 @@ class AudiobookShelfSensor(CoordinatorEntity, SensorEntity):
                 native_value, self.entity_description.key_context_method, None
             )
         return native_value
-
-    @property
-    def device_info(self) -> DeviceInfo | None:
-        """Return device information about this entity."""
-        return {
-            "identifiers": {(DOMAIN, self.coordinator.api_url)},
-            "name": "Audiobookshelf",
-            "manufacturer": "advplyr",
-            "sw_version": VERSION,
-            "configuration_url": self.coordinator.api_url,
-        }
-
-    @property
-    def unique_id(self) -> str:
-        """Return a unique ID."""
-        # Create unique IDs for each sensor that include the API URL
-        url = self.coordinator.api_url
-        key = self.entity_description.key
-        key_context = self.entity_description.key_context
-        key_context_method = self.entity_description.key_context_method
-        return f"{url}_{key}_{key_context}_{key_context_method}"

--- a/custom_components/audiobookshelf/translations/en.json
+++ b/custom_components/audiobookshelf/translations/en.json
@@ -31,6 +31,37 @@
             "reauth_successful": "Re-authentication was successful"
         }
     },
+    "entity": {
+        "sensor": {
+            "count_users": {
+                "name": "Users"
+            },
+            "count_users_online": {
+                "name": "Users online"
+            },
+            "count_open_sessions": {
+                "name": "Open sessions"
+            },
+            "count_recent_sessions": {
+                "name": "Recent sessions"
+            },
+            "count_auth_sessions": {
+                "name": "Auth sessions"
+            },
+            "count_libraries": {
+                "name": "Libraries"
+            },
+            "library_size": {
+                "name": "{library} size"
+            },
+            "library_items": {
+                "name": "{library} items"
+            },
+            "library_duration": {
+                "name": "{library} duration"
+            }
+        }
+    },
     "services": {
         "remove_my_progress": {
             "name": "Remove My Progress",

--- a/tests/test_migration.py
+++ b/tests/test_migration.py
@@ -1,0 +1,118 @@
+"""Tests for the v1 to v2 config entry migration."""
+
+import asyncio
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+from homeassistant.const import CONF_URL
+
+import custom_components.audiobookshelf as integration
+from custom_components.audiobookshelf.const import DOMAIN
+
+URL = "http://abs.local:13378"
+
+
+def _entry(version: int = 1) -> Any:
+    """Build a config entry stub at the given schema version."""
+    entry = MagicMock()
+    entry.version = version
+    entry.entry_id = "entry-1"
+    entry.data = {CONF_URL: URL}
+    return entry
+
+
+def _migrate(
+    entry: Any, unique_ids: list[str], *, device: Any = None
+) -> dict[str, Any]:
+    """Run the migration over stub registries and return what it touched."""
+    registry_entries = [
+        SimpleNamespace(entity_id=f"sensor.stub_{index}", unique_id=unique_id)
+        for index, unique_id in enumerate(unique_ids)
+    ]
+    entity_registry = MagicMock()
+    device_registry = MagicMock()
+    device_registry.async_get_device.return_value = device
+    hass = MagicMock()
+
+    with (
+        patch.object(integration.er, "async_get", return_value=entity_registry),
+        patch.object(
+            integration.er,
+            "async_entries_for_config_entry",
+            return_value=registry_entries,
+        ),
+        patch.object(integration.dr, "async_get", return_value=device_registry),
+    ):
+        result = asyncio.run(integration.async_migrate_entry(hass, entry))
+
+    return {
+        "result": result,
+        "entities": entity_registry.async_update_entity,
+        "devices": device_registry.async_update_device,
+        "hass": hass,
+    }
+
+
+def test_entity_unique_ids_move_onto_the_entry_id() -> None:
+    """v1 keyed entities on the API URL, which the user can edit."""
+    outcome = _migrate(_entry(), [f"{URL}_count_users_None_None"])
+
+    assert outcome["result"] is True
+    outcome["entities"].assert_called_once_with(
+        "sensor.stub_0",
+        new_unique_id="entry-1_count_users_None_None",
+    )
+
+
+def test_library_unique_ids_keep_their_suffix() -> None:
+    """Only the URL prefix changes, so library and stat stay addressable."""
+    outcome = _migrate(_entry(), [f"{URL}_library_stats_lib-1_total_size"])
+
+    outcome["entities"].assert_called_once_with(
+        "sensor.stub_0",
+        new_unique_id="entry-1_library_stats_lib-1_total_size",
+    )
+
+
+def test_unrecognised_unique_ids_are_left_alone() -> None:
+    """An id that does not carry the old prefix must not be rewritten."""
+    outcome = _migrate(_entry(), ["entry-1_count_users_None_None", "something-else"])
+
+    outcome["entities"].assert_not_called()
+
+
+def test_device_identifiers_are_rekeyed() -> None:
+    """Rekeying rather than recreating preserves the area and any renaming."""
+    outcome = _migrate(_entry(), [], device=SimpleNamespace(id="dev-1"))
+
+    outcome["devices"].assert_called_once_with(
+        "dev-1", new_identifiers={(DOMAIN, "entry-1")}
+    )
+
+
+def test_missing_device_is_not_an_error() -> None:
+    """A fresh entry that never registered a device still migrates."""
+    outcome = _migrate(_entry(), [], device=None)
+
+    assert outcome["result"] is True
+    outcome["devices"].assert_not_called()
+
+
+def test_entry_version_is_bumped() -> None:
+    """Without this the migration would run on every restart."""
+    entry = _entry()
+    outcome = _migrate(entry, [])
+
+    outcome["hass"].config_entries.async_update_entry.assert_called_once_with(
+        entry, version=2
+    )
+
+
+def test_already_migrated_entry_is_untouched() -> None:
+    """A v2 entry must not be rewritten again."""
+    outcome = _migrate(_entry(version=2), [f"{URL}_count_users_None_None"])
+
+    assert outcome["result"] is True
+    outcome["entities"].assert_not_called()
+    outcome["hass"].config_entries.async_update_entry.assert_not_called()

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -1,13 +1,23 @@
 """Tests for how sensors read values out of the coordinator's data."""
 
+import json
+from pathlib import Path
 from types import SimpleNamespace
 from typing import Any
 from unittest.mock import MagicMock, patch
 
+from homeassistant.helpers.device_registry import DeviceEntryType
+
+from custom_components.audiobookshelf import sensor as sensor_module
+from custom_components.audiobookshelf.const import DOMAIN
 from custom_components.audiobookshelf.sensor import (
+    SENSOR_DESCRIPTIONS,
     AudiobookShelfSensor,
     AudiobookShelfSensorEntityDescription,
 )
+
+# Built per library at runtime, so they are not in SENSOR_DESCRIPTIONS.
+LIBRARY_TRANSLATION_KEYS = ("library_size", "library_items", "library_duration")
 
 LIBRARY_SENSOR = AudiobookShelfSensorEntityDescription(
     key="library_stats",
@@ -60,6 +70,51 @@ def test_global_sensor_is_unaffected_by_library_stats() -> None:
     sensor = _sensor(GLOBAL_SENSOR, {"count_users": 4, "library_stats": {}})
     assert sensor.native_value == 4
     assert sensor.available is True
+
+
+def test_identity_is_keyed_on_the_entry_not_the_url() -> None:
+    """The URL is user-editable, so identity derived from it orphans entities."""
+    coordinator = MagicMock()
+    coordinator.api_url = "http://abs.local:13378"
+    entry = MagicMock()
+    entry.entry_id = "entry-1"
+
+    sensor = AudiobookShelfSensor(coordinator, entry, LIBRARY_SENSOR)
+
+    assert sensor.unique_id == "entry-1_library_stats_lib-1_total_items"
+    assert sensor.device_info is not None
+    assert sensor.device_info["identifiers"] == {(DOMAIN, "entry-1")}
+    assert sensor.device_info["entry_type"] is DeviceEntryType.SERVICE
+    # Was the integration version, which reads as the server version.
+    assert "sw_version" not in sensor.device_info
+    assert sensor.has_entity_name is True
+
+
+def _entity_translations() -> dict[str, Any]:
+    """Load the sensor entity names shipped in en.json."""
+    path = Path(sensor_module.__file__).parent / "translations" / "en.json"
+    names: dict[str, Any] = json.loads(path.read_text(encoding="utf-8"))["entity"][
+        "sensor"
+    ]
+    return names
+
+
+def test_every_translation_key_has_a_name() -> None:
+    """A key with no entry silently yields an entity with no name."""
+    names = _entity_translations()
+    keys = [d.translation_key for d in SENSOR_DESCRIPTIONS]
+
+    assert all(key is not None for key in keys)
+    assert set(keys) <= set(names)
+    assert set(LIBRARY_TRANSLATION_KEYS) <= set(names)
+
+
+def test_library_names_carry_the_placeholder() -> None:
+    """Without {library} every library's sensors would share one name."""
+    names = _entity_translations()
+
+    for key in LIBRARY_TRANSLATION_KEYS:
+        assert "{library}" in names[key]["name"]
 
 
 def test_none_value_stays_none() -> None:


### PR DESCRIPTION
Third pass from the review, and the breaking one. #131 fixed what was
actively breaking, #132 fixed the structure underneath it; this fixes
entity identity, which could not be done without a migration.

## The problem

`unique_id` and the device identifier were both built from the API URL:

```python
return f"{url}_{key}_{key_context}_{key_context_method}"
```
```python
"identifiers": {(DOMAIN, self.coordinator.api_url)},
```

The URL is user-editable. Moving the server from an IP to a hostname,
switching to https, or adding a port gave every sensor a new unique id
and created a second device, orphaning the originals along with their
recorder history, dashboard cards and automation references. The HA
entity docs name URLs explicitly among unacceptable identifier sources,
alongside IP address and device name, for exactly this reason.

Identity now derives from `entry.entry_id`, which is stable for the life
of the entry.

## The migration

This is the part worth reviewing closely, since getting it wrong loses
user history silently.

`async_migrate_entry` runs at v1 and does two things:

- Rewrites entity unique ids by swapping the URL prefix for the entry id
  and keeping the remainder byte for byte. Deliberately not normalising
  the trailing `_None_None` segments: keeping the suffix untouched makes
  the transformation a pure prefix swap, which is far easier to verify
  than a reformat. Anything not carrying the old prefix is skipped.
- Rekeys the existing device rather than letting a new one appear, so its
  area assignment and any renaming survive.

`ConfigFlow.VERSION` goes to 2. A fresh install starts at 2 and never
migrates.

I verified every registry API used here against the pinned HA 2025.1.4
rather than assuming: `async_update_entity(new_unique_id=...)`
(`entity_registry.py:1043`), `async_entries_for_config_entry`
(`:1483`), `async_get_device(identifiers=...)`
(`device_registry.py:654`) and `async_update_device(new_identifiers=...)`
(`:872`).

## Naming

`has_entity_name` is set and names move into entity translations.

Displayed names are unchanged for the six global sensors: the device
name now supplies the "Audiobookshelf" prefix that was previously
hardcoded into every `name=`, so "Audiobookshelf Users" still renders as
"Audiobookshelf Users". Library sensors use a `{library}` placeholder
via `translation_placeholders`, which `EntityDescription` carries
directly (`entity.py:250`), so the name is built from data rather than
interpolated in code.

Existing entity ids are untouched, since the registry preserves them
across a rename.

## Device metadata

Added `DeviceEntryType.SERVICE`, which the device registry documents for
an integration representing a service rather than hardware, and which
now matches `integration_type: service` from #132.

Dropped `sw_version`. It was set to the integration's own `VERSION`
constant, in a field the docs define as the device's version, so the
device page showed something a user would reasonably read as their
Audiobookshelf server version. Populating it properly means reading
`serverVersion` from the server, which is worth doing alongside #17
rather than guessing at an endpoint here. Note `VERSION` in `const.py`
now has no remaining consumer, though CLAUDE.md's release process still
documents bumping it.

## Testing

47 tests, 9 new. `tests/test_migration.py` covers the prefix swap, that
the library and stat portion of the key survives it, that unrecognised
ids are left alone, the device rekey, a missing device, the version
bump, and that a v2 entry is not touched again.

Negative control: replacing `async_migrate_entry` with a bare
`return True` fails exactly the four tests that assert the migration
acts, while the three asserting it does not over-reach still pass, which
is the split you want.

`tests/test_sensor.py` gains a check that every `translation_key` has a
matching entry in `en.json` and that the library names keep their
placeholder. A typo there produces an entity with no name and nothing in
CI catches it.

ruff, ruff format, mypy and pytest all clean.

## Note on CI

Hassfest and HACS validation will run on this PR since it targets `main`.
They did not run on #132 while it targeted a branch: `hacs.yml` triggers
only on pull requests to `main`, so a stacked PR shows a green tick from
Lint and Test alone. Worth fixing in the CI pass.
