### PR TITLE
ci: harden workflows and close the gaps that let checks be skipped

### DIFF
--- a/.github/workflows/hacs.yml
+++ b/.github/workflows/hacs.yml
@@ -4,12 +4,17 @@ on:
   push:
     branches:
       - "main"
+  # Deliberately not restricted to pull requests targeting main. With that
+  # filter a stacked pull request ran only Lint and Test, so a manifest or
+  # services.yaml change showed a green tick from a check set that never
+  # validated it.
   pull_request:
-    branches:
-      - "main"
   schedule:
     - cron: "00 12 * * 1"
   workflow_dispatch:
+
+permissions:
+  contents: read
 
 jobs:
   hassfest: # https://developers.home-assistant.io/blog/2020/04/16/hassfest
@@ -18,6 +23,10 @@ jobs:
     steps:
       - name: checkout
         uses: "actions/checkout@v7.0.1"
+      # Left on the upstream-recommended moving refs rather than pinned to a
+      # commit: both exist to check this repo against what Home Assistant and
+      # HACS require *now*, and pinning them freezes that at the pin date. The
+      # read-only token above is the mitigation for the mutable ref.
       - name: validation
         uses: home-assistant/actions/hassfest@master
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,16 +1,16 @@
 name: Lint
 
+# No path filter. The previous one listed only '**.py', 'requirements.txt' and
+# a '**/.github/workflows/*.y*ml' glob that never matched, so a change to
+# .ruff.toml or mypy.ini skipped linting entirely. Enumerating every relevant
+# path is a trap that already caught this repo out once, and a run costs well
+# under two minutes.
 on:
   push:
-    paths:
-      - '**.py'
-      - 'requirements.txt'
-      - '**/.github/workflows/*.y*ml'
   pull_request:
-    paths:
-      - '**.py'
-      - 'requirements.txt'
-      - '**/.github/workflows/*.y*ml'
+
+permissions:
+  contents: read
 
 jobs:
   lint:
@@ -29,11 +29,13 @@ jobs:
         - name: "Install requirements"
           run: python3 -m pip install -r requirements.txt
 
+        # Covers tests/ as well as the component, matching the commands
+        # CLAUDE.md documents for verifying a change locally.
         - name: "Lint"
-          run: python3 -m ruff check ./custom_components/audiobookshelf
+          run: python3 -m ruff check .
 
         - name: Run MyPy
-          run: python3 -m mypy custom_components/audiobookshelf
+          run: python3 -m mypy custom_components/audiobookshelf tests
 
         - name: "Format"
-          run: python3 -m ruff format ./custom_components/audiobookshelf --check
+          run: python3 -m ruff format . --check

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,17 +13,58 @@ jobs:
     runs-on: "ubuntu-latest"
     permissions:
       contents: write
+    env:
+      TAG: ${{ github.ref_name }}
     steps:
       - name: "Checkout the repository"
         uses: "actions/checkout@v7.0.1"
 
+      # const.py and manifest.json hold the version separately and drift
+      # silently. Catch it here rather than after the release is published.
+      - name: "Check the version matches the tag"
+        shell: "bash"
+        run: |
+          python3 - <<'PY'
+          import json
+          import os
+          import pathlib
+          import re
+          import sys
+
+          tag = os.environ["TAG"]
+          component = pathlib.Path("custom_components/audiobookshelf")
+
+          const = (component / "const.py").read_text(encoding="utf-8")
+          const_version = re.search(r'^VERSION = "([^"]+)"', const, re.M).group(1)
+          manifest = json.loads((component / "manifest.json").read_text(encoding="utf-8"))
+
+          problems = []
+          if const_version != tag:
+              problems.append(f"const.py VERSION is {const_version}, tag is {tag}")
+          if manifest["version"] != tag.removeprefix("v"):
+              problems.append(
+                  f"manifest.json version is {manifest['version']}, tag is {tag}"
+              )
+
+          for problem in problems:
+              print(f"::error::{problem}")
+          sys.exit(1 if problems else 0)
+          PY
+
+      # The tag reaches bash through the environment, never through template
+      # expansion: git permits $, backticks and quotes in a tag name, so an
+      # interpolated "${{ github.ref_name }}" here would be a command injection
+      # into a job that holds contents: write.
       - name: "ZIP the integration directory"
         shell: "bash"
         run: |
           cd "${{ github.workspace }}/custom_components/audiobookshelf"
-          zip "Audiobookshelf_${{ github.ref_name }}.zip" -r ./
+          zip "Audiobookshelf_$TAG.zip" -r ./
 
+      # Pinned to a commit: this step holds a write-scoped token and builds the
+      # archive offered on the release, so a moved tag upstream would reach
+      # anyone installing it.
       - name: "Upload the ZIP file to the release"
-        uses: "softprops/action-gh-release@v3.0.2"
+        uses: "softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228" # v3.0.2
         with:
-          files: ${{ github.workspace }}/custom_components/audiobookshelf/Audiobookshelf_${{ github.ref_name }}.zip
+          files: ${{ github.workspace }}/custom_components/audiobookshelf/Audiobookshelf_${{ env.TAG }}.zip

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,16 +1,12 @@
 name: Test
 
+# No path filter, for the reason given in lint.yml.
 on:
   push:
-    paths:
-      - '**.py'
-      - 'requirements.txt'
-      - '**/.github/workflows/*.y*ml'
   pull_request:
-    paths:
-      - '**.py'
-      - 'requirements.txt'
-      - '**/.github/workflows/*.y*ml'
+
+permissions:
+  contents: read
 
 jobs:
   test:


### PR DESCRIPTION
Fourth pass from the review. Two of these were found by the review agents;
the third-from-last was found while working on #132, when a stacked pull
request showed all checks green having never run hassfest at all.

## Command injection in the release job

```yaml
run: |
  cd "${{ github.workspace }}/custom_components/audiobookshelf"
  zip "Audiobookshelf_${{ github.ref_name }}.zip" -r ./
```

`${{ }}` is expanded by the templating engine *before* bash parses the
line, and `git check-ref-format` permits `$`, backticks, quotes,
semicolons and pipes in a tag name. So a crafted tag executed arbitrary
commands in a job holding `contents: write` whose output is the archive
offered on the release page.

Creating a tag needs write access, so this is not an unauthenticated
path. It is a privilege-laundering step for a compromised account or any
bot with tag-create rights, and it is a one-line fix: the tag now reaches
bash through the environment as `"$TAG"`.

## Checks that could silently not run

Two separate ways a change could get a green tick from checks that never
looked at it.

`hacs.yml` triggered on `pull_request: branches: [main]`, so **#132 ran
Lint and Test only** while it targeted a stacked branch. It changed
`manifest.json` and added `async_setup`, which activates hassfest's
`config_schema` plugin. I had to dispatch the workflow by hand to
validate it. Now runs on every pull request.

`lint.yml` and `tests.yml` filtered on `'**.py'`, `'requirements.txt'`
and `'**/.github/workflows/*.y*ml'` — that last glob has a leading `**/`
and never matched anything. A change to `.ruff.toml`, `mypy.ini` or the
translations ran neither job.

I removed the path filters rather than extending them. Enumerating every
relevant path is a maintenance trap that has already caught this repo
out, the list would now need to include the translations because a test
reads them, and each job takes under two minutes. Happy to restore an
extended filter instead if you would rather keep them.

## CI was weaker than the documented local checks

`lint.yml` ran ruff and mypy against `custom_components/audiobookshelf`
only, while CLAUDE.md's "Verifying a change" section documents `.` and
`tests/`. So test code was never linted or type-checked in CI. Both now
match the documented commands.

## Version drift at release

CLAUDE.md warns that `const.py` `VERSION` and `manifest.json` `version`
"are separate values and drift silently", and nothing verified them. The
release job now checks both against the tag before building the archive,
reading the tag from the environment so the check itself is not another
injection point.

Verified both directions against the current tree:

```
=== matching tag v0.3.0 ===
exit=0
=== mismatched tag v0.4.0 ===
::error::const.py VERSION is v0.3.0, tag is v0.4.0
::error::manifest.json version is 0.3.0, tag is v0.4.0
exit=1
```

## Supply chain

`softprops/action-gh-release` is pinned to commit `3d0d9888`, which I
resolved from the `v3.0.2` annotated tag and confirmed is the "release
3.0.2 (#818)" commit. That step holds a write-scoped token and builds
what people install, so a moved tag upstream would reach end users.

`home-assistant/actions/hassfest@master` and `hacs/action@main` are
deliberately **not** pinned. Both exist to check this repo against what
Home Assistant and HACS require *now*, and pinning them to a commit
freezes that at the pin date, which defeats the point of running them.
The mitigation is the token: all three workflows previously declared no
`permissions` at all and inherited the repository default, which on
repositories created before GitHub changed it is read **and write**. They
are now `contents: read`.

## Not included

Deleting the seven stale dependabot branches. Their pull requests are all
closed and their contents are older than main, so merging any would be a
downgrade, but deleting remote branches is not something I wanted to do
without asking.
