### PR TITLE
docs: correct the working notes and document the action

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,7 +25,7 @@ Then read the actual hunks for anything that did change, at
 
 ### Endpoints this integration depends on
 
-Check each of these on every server release. The first five back sensors; the rest back
+Check each of these on every server release. The first six back sensors; the rest back
 the `remove_my_progress` service.
 
 | Endpoint | Used for | Notes |
@@ -54,8 +54,14 @@ as a `Bearer` token:
 - **Refresh tokens** — rejected for API auth since 2.36.0. This integration never sends one.
 
 The credential must belong to an **admin/root** user. `verify_config` uses
-`get_admin_client_by_token` deliberately so a non-admin key is rejected at setup rather than
-failing on every poll afterwards.
+`get_admin_client_by_token` deliberately so a non-admin key is rejected in the config flow
+rather than failing on every poll afterwards.
+
+`verify_config` is only reachable from the config flow now. It used to run again in
+`async_setup_entry`, which duplicated a request on every restart and reload over its own
+`ClientSession`; `async_config_entry_first_refresh` already gates setup. A non-admin key that
+somehow reaches setup is caught by the coordinator, which handles `BadUserError` ahead of
+`AbsAuthError` to say so specifically.
 
 ### The exception trap
 
@@ -74,12 +80,34 @@ refresh token, and raises `TokenIsMissingError`. Both are `AbsAuthError`, so cat
 `NotFoundError` (HTTP 404) is *not* an `AbsAuthError` — that is what lets `count_auth_sessions`
 degrade to `None` on pre-2.36.0 servers instead of prompting for reauth.
 
+`BadUserError` (non-admin credential) *is* an `AbsAuthError`, so it must be caught before it if
+you want a message that says so rather than a generic auth failure.
+
+There is a third clause that is easy to leave out. Every `from_json` call raises **mashumaro**
+exceptions on schema drift — `MissingField` (a `LookupError`) and `InvalidFieldValue` (a
+`ValueError`) — and a non-JSON body raises `JSONDecodeError` (also a `ValueError`). None of
+these are `AbsError` *or* `ClientError`. Without `except (ValueError, LookupError)` they escape
+the coordinator entirely and Home Assistant logs a full traceback on every poll instead of a
+clean `UpdateFailed`.
+
 Note also that `_get` changed behaviour across library versions: 404 used to return `b""` and
 now raises. Re-check this when bumping `aioaudiobookshelf`.
 
+### Platform setup must not call the API
+
+`sensor.py` used to call `/api/libraries` again during `async_setup_entry` to name its
+per-library entities. A transient failure there is swallowed by the platform forward, so the
+entry stayed `LOADED` with no entities — and because the coordinator only schedules a refresh
+while it has listeners, **polling then stopped permanently**, with the integration still
+showing as healthy. It took a restart or manual reload to recover.
+
+The library list is now stashed on the coordinator by `library_stats()` and read from there.
+Keep it that way: anything the sensor platform needs should come from data the first refresh
+already fetched.
+
 ## Verifying a change
 
-All three must be clean. `uvx` avoids touching the system Python:
+All four must be clean. `uvx` avoids touching the system Python:
 
 ```bash
 uvx ruff@0.16.0 check .
@@ -90,22 +118,35 @@ uvx ruff@0.16.0 format --check .
 ```
 
 ```bash
-uvx --prerelease=allow --with homeassistant==2025.1.4 --with aioaudiobookshelf==0.1.24 --with voluptuous --with pytest mypy@2.3.0 --config-file mypy.ini custom_components/audiobookshelf/ tests/
+uvx --python 3.12 --prerelease=allow --with homeassistant==2025.1.4 --with aioaudiobookshelf==0.1.24 --with voluptuous --with pytest mypy@2.3.0 --config-file mypy.ini custom_components/audiobookshelf/ tests/
 ```
 
 ```bash
-uvx --prerelease=allow --with homeassistant==2025.1.4 --with aioaudiobookshelf==0.1.24 pytest@9.1.1 tests/ -q -W ignore::DeprecationWarning
+uvx --python 3.12 --prerelease=allow --with homeassistant==2025.1.4 --with aioaudiobookshelf==0.1.24 pytest@9.1.1 tests/ -q -W ignore::DeprecationWarning
 ```
 
 `--prerelease=allow` is required because `homeassistant` depends on a pre-release of
 `aiohasupervisor`. Without it the resolve fails outright.
 
+`--python 3.12` is not optional in practice. Once `uv` has cached a newer toolchain it will
+re-resolve to it, and `homeassistant==2025.1.4` cannot build there — `orjson==3.10.12` has no
+wheel for 3.14. Without the flag the same command works one day and fails the next.
+
+CI runs exactly these, minus the pins, via `requirements.txt`. It lints and type-checks
+`tests/` as well as the component, so a change that only passes locally because you scoped the
+command narrower will still fail there.
+
 When bumping a pinned tool, run it against a pristine tree first (`git archive HEAD` into a
 temp dir) so pre-existing findings are not mistaken for regressions.
 
-Static checks are the real safety net here — the test suite is small and covers pure logic
-only (config validation and response schemas). Anything touching Home Assistant runtime
-behaviour is not covered and needs the live test below.
+The test suite covers the coordinator's exception mapping, sensor value derivation and
+availability, the `remove_my_progress` guards, and the v1 to v2 entity migration — all with
+plain `pytest` and `unittest.mock`, no `hass` fixture. Do not reach for
+`pytest-homeassistant-custom-component`: every release caps `pytest` at `<=8.3.4` and conflicts
+with the pinned 9.1.1, and nothing here has needed it.
+
+What is still *not* covered, and needs the live test below: the config flow as a flow, reauth
+end to end, and anything that depends on Home Assistant actually wiring entities up.
 
 ## Testing against a real server
 
@@ -152,23 +193,50 @@ These cost real time. All were hit in practice.
 ## Dependencies
 
 `requirements.txt` is **CI and development only**. HACS ships `custom_components/audiobookshelf/`,
-and `manifest.json` declares the only runtime requirement (`aioaudiobookshelf`, unpinned).
+and `manifest.json` declares the only runtime requirement (`aioaudiobookshelf`).
 
 This matters for triaging Dependabot: advisories against `homeassistant` in `requirements.txt`
 affect the Actions runner, not any user of the integration, and should be weighted accordingly.
 
-Because `manifest.json` is unpinned, users always get the newest `aioaudiobookshelf`. Keep the
-`requirements.txt` pin at that same version or CI tests something users never run.
+`manifest.json` bounds `aioaudiobookshelf` to `>=0.1.24,<0.2` rather than leaving it open. The
+coordinator reaches into `client._get()` in six places because the library exposes no public
+accessor for these endpoints, and `_get`'s 404 behaviour has already changed once between
+versions. Unbounded, a single upstream release would break every install at once with no code
+change here. The cost is that a new minor has to be adopted deliberately: bump the bound and
+the `requirements.txt` pin together, and re-read the exception trap section above.
+
+Keep the `requirements.txt` pin at the newest version the bound allows, or CI tests something
+users never run.
 
 ## Releasing
 
-Bump the version in **both** places — they are separate values and drift silently:
+Bump the version in **both** places — they are separate values and used to drift silently:
 
 - `custom_components/audiobookshelf/const.py` -> `VERSION = "vX.Y.Z"` (with `v`)
 - `custom_components/audiobookshelf/manifest.json` -> `"version": "X.Y.Z"` (without `v`)
 
+`release.yml` now checks both against the tag and fails the release if either disagrees, so
+the drift is caught rather than shipped. `VERSION` has no remaining consumer in the code — it
+was removed from `device_info`, where it was being reported as the *server's* version — but it
+still has to be bumped, because the gate compares it to the tag.
+
 `hacs.json` separately declares the minimum supported Home Assistant version.
 
 Releases are cut from `main` after merge. Publishing a GitHub release triggers
-`.github/workflows/release.yml`, which zips the component and attaches it — that asset is what
-HACS installs, so confirm it exists on the release before considering it done.
+`.github/workflows/release.yml`, which zips the component and attaches it to the release.
+
+**That asset is not what HACS installs.** `hacs.json` does not set `zip_release`, so HACS
+downloads the individual files under `custom_components/audiobookshelf/` at the tag and ignores
+the archive entirely. The archive exists for the manual-install path in the README. Opting in
+to `zip_release` would mean giving the asset a stable filename, which the current
+`Audiobookshelf_$TAG.zip` is not.
+
+## Config entry schema version
+
+`ConfigFlow.VERSION` is **2**. It went from 1 when entity unique IDs and the device identifier
+moved off the API URL (user-editable, so changing it orphaned everything) onto `entry.entry_id`.
+
+Anything that changes the shape of a unique ID from now on needs a matching bump and a branch
+in `async_migrate_entry`. The v1 migration is a pure prefix swap that keeps the rest of the key
+byte for byte, which is deliberate — it is far easier to verify than a reformat, and the
+trailing `_None_None` segments are invisible to users.

--- a/README.md
+++ b/README.md
@@ -13,21 +13,40 @@
 
 ## This component will set up the following general sensors:
 
-| Entity            |       Type       | Description                                            |
-| ---------------   | ---------------- | ------------------------------------                   |
-| `open_sessions`   | `sensor`         | Show number of open audio sessions                     |
-| `recent_sessions` | `sensor`         | Show number of open audio sessions updated recently    |
-| `libraries`       | `sensor`         | Number of libraries on the server                      |
-| `users`           | `sensor`         | Number of users on the server                          |
-| `online_users`    | `sensor`         | Number of online users on the server                   |
-| `auth_sessions`   | `sensor`         | Number of active authentication sessions for the configured user (requires Audiobookshelf v2.36.0+) |
+| Entity                                  |  Type    | Description                                            |
+| --------------------------------------- | -------- | ------------------------------------                   |
+| `sensor.audiobookshelf_open_sessions`   | `sensor` | Number of open audio sessions                          |
+| `sensor.audiobookshelf_recent_sessions` | `sensor` | Number of open audio sessions updated in the last two minutes |
+| `sensor.audiobookshelf_libraries`       | `sensor` | Number of libraries on the server                      |
+| `sensor.audiobookshelf_users`           | `sensor` | Number of users on the server                          |
+| `sensor.audiobookshelf_users_online`    | `sensor` | Number of online users on the server                   |
+| `sensor.audiobookshelf_auth_sessions`   | `sensor` | Number of active authentication sessions for the configured user (requires Audiobookshelf v2.36.0+, otherwise `unknown`) |
 
 ## It also adds the following library specific sensors (for each library that it finds during setup):
-| Entity             | Type           | Description                                              |
-| ------------------ | -------------- | -------------------------------------------------------- |
-| `items`            | `sensor`       | Number of items in the library                           |
-| `duration`         | `sensor`       | Total time in hours of playable content in library       |
-| `size`             | `sensor`       | Total disk space used by library in GB                   |
+| Entity                                       | Type     | Description                                        |
+| -------------------------------------------- | -------- | -------------------------------------------------- |
+| `sensor.audiobookshelf_<library>_items`      | `sensor` | Number of items in the library                     |
+| `sensor.audiobookshelf_<library>_duration`   | `sensor` | Total playable content in the library, shown in hours by default |
+| `sensor.audiobookshelf_<library>_size`       | `sensor` | Total disk space used by the library, shown in GB by default |
+
+Library sensors are created for the libraries that exist when the integration starts. Reload the integration after adding or removing a library on the server, otherwise the new library is counted by `sensor.audiobookshelf_libraries` without getting sensors of its own.
+
+## Actions
+
+### `audiobookshelf.remove_my_progress`
+
+Removes listening progress from every book whose series name matches the text you give it. **This cannot be undone.**
+
+| Field         | Required | Description                                                                              |
+| ------------- | -------- | ---------------------------------------------------------------------------------------- |
+| `series_name` | yes      | Matched as a substring against each book's series name, ignoring case. Cannot be blank.  |
+
+Two things are worth knowing before using it:
+
+- It removes progress for **the account the API key belongs to**, not for the Home Assistant user calling the action. The name is misleading in that respect.
+- The match is a substring, so `Dune` also matches `Dune Chronicles`. Give as much of the series name as you can.
+
+It walks every item in every library, so it can take a while on a large server. Podcast libraries are unaffected.
 
 ## Examples
 
@@ -78,6 +97,8 @@ For more info on what the key can be used for see: https://api.audiobookshelf.or
 | `URL`           | The URL and port of your Audiobookshelf instance (must start with the protocol, http:// or https://)      |
 | `API key`       | The API key that you got in the previous step                                                             |
 | `Scan interval` | How regularly the data should be fetched from your Audiobookshelf instance (in seconds), defaults to 300s |
+
+Only one Audiobookshelf server can be configured at a time. To point the integration at a different server, remove the existing entry first.
 
 ## Credits
 

--- a/custom_components/audiobookshelf/manifest.json
+++ b/custom_components/audiobookshelf/manifest.json
@@ -14,7 +14,7 @@
     "aioaudiobookshelf"
   ],
   "requirements": [
-    "aioaudiobookshelf"
+    "aioaudiobookshelf>=0.1.24,<0.2"
   ],
   "single_config_entry": true,
   "version": "0.3.0"

--- a/info.md
+++ b/info.md
@@ -8,21 +8,40 @@
 
 ## This component will set up the following general sensors:
 
-| Entity            |       Type       | Description                                            |
-| ---------------   | ---------------- | ------------------------------------                   |
-| `open_sessions`   | `sensor`         | Show number of open audio sessions                     |
-| `recent_sessions` | `sensor`         | Show number of open audio sessions updated recently    |
-| `libraries`       | `sensor`         | Number of libraries on the server                      |
-| `users`           | `sensor`         | Number of users on the server                          |
-| `online_users`    | `sensor`         | Number of online users on the server                   |
-| `auth_sessions`   | `sensor`         | Number of active authentication sessions for the configured user (requires Audiobookshelf v2.36.0+) |
+| Entity                                  |  Type    | Description                                            |
+| --------------------------------------- | -------- | ------------------------------------                   |
+| `sensor.audiobookshelf_open_sessions`   | `sensor` | Number of open audio sessions                          |
+| `sensor.audiobookshelf_recent_sessions` | `sensor` | Number of open audio sessions updated in the last two minutes |
+| `sensor.audiobookshelf_libraries`       | `sensor` | Number of libraries on the server                      |
+| `sensor.audiobookshelf_users`           | `sensor` | Number of users on the server                          |
+| `sensor.audiobookshelf_users_online`    | `sensor` | Number of online users on the server                   |
+| `sensor.audiobookshelf_auth_sessions`   | `sensor` | Number of active authentication sessions for the configured user (requires Audiobookshelf v2.36.0+, otherwise `unknown`) |
 
 ## It also adds the following library specific sensors (for each library that it finds during setup):
-| Entity             | Type           | Description                                              |
-| ------------------ | -------------- | -------------------------------------------------------- |
-| `items`            | `sensor`       | Number of items in the library                           |
-| `duration`         | `sensor`       | Total time in hours of playable content in library       |
-| `size`             | `sensor`       | Total disk space used by library in GB                   |
+| Entity                                       | Type     | Description                                        |
+| -------------------------------------------- | -------- | -------------------------------------------------- |
+| `sensor.audiobookshelf_<library>_items`      | `sensor` | Number of items in the library                     |
+| `sensor.audiobookshelf_<library>_duration`   | `sensor` | Total playable content in the library, shown in hours by default |
+| `sensor.audiobookshelf_<library>_size`       | `sensor` | Total disk space used by the library, shown in GB by default |
+
+Library sensors are created for the libraries that exist when the integration starts. Reload the integration after adding or removing a library on the server, otherwise the new library is counted by `sensor.audiobookshelf_libraries` without getting sensors of its own.
+
+## Actions
+
+### `audiobookshelf.remove_my_progress`
+
+Removes listening progress from every book whose series name matches the text you give it. **This cannot be undone.**
+
+| Field         | Required | Description                                                                              |
+| ------------- | -------- | ---------------------------------------------------------------------------------------- |
+| `series_name` | yes      | Matched as a substring against each book's series name, ignoring case. Cannot be blank.  |
+
+Two things are worth knowing before using it:
+
+- It removes progress for **the account the API key belongs to**, not for the Home Assistant user calling the action. The name is misleading in that respect.
+- The match is a substring, so `Dune` also matches `Dune Chronicles`. Give as much of the series name as you can.
+
+It walks every item in every library, so it can take a while on a large server. Podcast libraries are unaffected.
 
 ## Examples
 
@@ -70,6 +89,14 @@ Use that key as the `API key` when setting up the integration.
 For more info on what the key can be used for see: https://api.audiobookshelf.org/#introduction
 
 ### Setting up via the UI
+
+| Variable        | Description                                                                                               |
+| --------------- | --------------------------------------------------------------------------------------------------------- |
+| `URL`           | The URL and port of your Audiobookshelf instance (must start with the protocol, http:// or https://)      |
+| `API key`       | The API key that you got in the previous step                                                             |
+| `Scan interval` | How regularly the data should be fetched from your Audiobookshelf instance (in seconds), defaults to 300s |
+
+Only one Audiobookshelf server can be configured at a time. To point the integration at a different server, remove the existing entry first.
 
 ## Credits
 


### PR DESCRIPTION
Documentation pass from the review. One item here is a factual error
currently on `main` that would have misled the next release.

## The wrong bit

CLAUDE.md said:

> Publishing a GitHub release triggers `.github/workflows/release.yml`,
> which zips the component and attaches it — that asset is what HACS
> installs, so confirm it exists on the release before considering it done.

`hacs.json` sets no `zip_release`, so HACS downloads the individual files
under `custom_components/audiobookshelf/` at the tag and ignores the
archive completely. The archive exists for the manual-install path in the
README. Corrected, with a note that opting in to `zip_release` would need
a stable asset filename, which `Audiobookshelf_$TAG.zip` is not.

## Entity ids that do not exist

README and info.md both documented `online_users`; the entity is
`sensor.audiobookshelf_users_online`. The library sensors were listed as
bare `items`, `duration` and `size` rather than
`sensor.audiobookshelf_<library>_items` and friends. Anyone copying
those into a template got an unknown entity.

Both tables now use full entity ids, and note that library sensors are
created at startup, so adding a library server-side leaves it counted by
`sensor.audiobookshelf_libraries` without sensors of its own until a
reload.

## The action was documented nowhere

`remove_my_progress` appeared in neither README nor info.md. Both now
describe it, including the two things a user cannot discover otherwise:

- it removes progress for **the account the API key belongs to**, not
  for the Home Assistant user calling it, which the name actively
  misleads about
- the match is a case-insensitive substring, so `Dune` also matches
  `Dune Chronicles`

info.md's "Setting up via the UI" heading also had no content under it at
all; it now carries the same table as the README.

## Working notes brought back in line

- The endpoint table says the first **six** back sensors, not five.
- `verify_config` no longer runs at setup, so the note about rejecting a
  non-admin key there now describes the config flow, plus the
  coordinator's `BadUserError` clause that replaced it.
- The claim that the suite "covers pure logic only" is no longer true;
  replaced with what is and is not covered, and why
  `pytest-homeassistant-custom-component` is not worth adopting here.

New traps, all found the hard way in #131 to #134:

- mashumaro's `MissingField` and `InvalidFieldValue` are neither
  `AbsError` nor `ClientError`, so schema drift needs its own clause or
  it escapes as a traceback every poll.
- The sensor platform must not call the API during setup. A failure there
  is swallowed by the platform forward, leaving the entry `LOADED` with
  no entities, and since the coordinator only schedules a refresh while
  it has listeners, polling then stops permanently while the integration
  still looks healthy.
- `ConfigFlow.VERSION` is 2, so any further change to unique id shape
  needs a migration.

`--python 3.12` is now documented on the `uvx` commands. Without it, once
`uv` has cached a newer toolchain it re-resolves to it and
`homeassistant==2025.1.4` cannot build there, so the documented commands
work one day and fail the next.

## The deferred dependency bound

`manifest.json` now bounds `aioaudiobookshelf` to `>=0.1.24,<0.2`. I held
this back from #132 because it contradicted CLAUDE.md's "users always get
the newest" note, and changing the code without the rationale is exactly
the drift that file exists to prevent. Both change together here.

The reasoning: the coordinator reaches into `client._get()` in six places
because no public accessor exists for those endpoints, and `_get`'s 404
behaviour has already changed once between versions. Unbounded, one
upstream release breaks every install at once with no change here. The
cost is that a new minor has to be adopted deliberately, which the
Dependencies section now spells out.

Verified the bound resolves to `0.1.24`, matching the `requirements.txt`
pin.

ruff, ruff format, mypy and pytest all clean.
