### PR TITLE
feat(sensor): create sensors for libraries added after setup

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -105,6 +105,10 @@ The library list is now stashed on the coordinator by `library_stats()` and read
 Keep it that way: anything the sensor platform needs should come from data the first refresh
 already fetched.
 
+That list is also what makes new libraries appear without a reload — the platform registers a
+coordinator listener that adds sensors for library ids it has not seen. It has to stay
+idempotent, because it runs on every poll.
+
 ## Verifying a change
 
 All four must be clean. `uvx` avoids touching the system Python:

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@
 | `sensor.audiobookshelf_<library>_duration`   | `sensor` | Total playable content in the library, shown in hours by default |
 | `sensor.audiobookshelf_<library>_size`       | `sensor` | Total disk space used by the library, shown in GB by default |
 
-Library sensors are created for the libraries that exist when the integration starts. Reload the integration after adding or removing a library on the server, otherwise the new library is counted by `sensor.audiobookshelf_libraries` without getting sensors of its own.
+A library created on the server gets its sensors automatically, at the next update. A library removed from the server leaves its sensors behind as `unavailable`; delete them from the entity registry if you want them gone.
 
 ## Actions
 

--- a/custom_components/audiobookshelf/sensor.py
+++ b/custom_components/audiobookshelf/sensor.py
@@ -4,6 +4,7 @@ from dataclasses import dataclass
 from logging import getLogger
 from typing import Any, Final
 
+from aioaudiobookshelf.schema.library import Library
 from homeassistant.components.sensor import (
     SensorDeviceClass,
     SensorEntity,
@@ -11,7 +12,7 @@ from homeassistant.components.sensor import (
     SensorStateClass,
 )
 from homeassistant.const import UnitOfInformation
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.device_registry import DeviceEntryType, DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
@@ -83,6 +84,50 @@ SENSOR_DESCRIPTIONS: Final[tuple[AudiobookShelfSensorEntityDescription, ...]] = 
 )
 
 
+def library_descriptions(
+    library: Library,
+) -> list[AudiobookShelfSensorEntityDescription]:
+    """Build the sensor descriptions for one library."""
+    return [
+        AudiobookShelfSensorEntityDescription(
+            key="library_stats",
+            key_context=library.id_,
+            key_context_method="total_size",
+            translation_key="library_size",
+            translation_placeholders={"library": library.name},
+            icon="mdi:harddisk",
+            device_class=SensorDeviceClass.DATA_SIZE,
+            state_class=SensorStateClass.MEASUREMENT,
+            native_unit_of_measurement=UnitOfInformation.BYTES,
+            suggested_unit_of_measurement=UnitOfInformation.GIGABYTES,
+            suggested_display_precision=2,
+        ),
+        AudiobookShelfSensorEntityDescription(
+            key="library_stats",
+            key_context=library.id_,
+            key_context_method="total_items",
+            translation_key="library_items",
+            translation_placeholders={"library": library.name},
+            icon="mdi:book-multiple",
+            state_class=SensorStateClass.MEASUREMENT,
+            native_unit_of_measurement="items",
+        ),
+        AudiobookShelfSensorEntityDescription(
+            key="library_stats",
+            key_context=library.id_,
+            key_context_method="total_duration",
+            translation_key="library_duration",
+            translation_placeholders={"library": library.name},
+            icon="mdi:timer-outline",
+            device_class=SensorDeviceClass.DURATION,
+            state_class=SensorStateClass.MEASUREMENT,
+            native_unit_of_measurement="s",
+            suggested_unit_of_measurement="h",
+            suggested_display_precision=0,
+        ),
+    ]
+
+
 async def async_setup_entry(
     hass: HomeAssistant,  # noqa: ARG001
     entry: AudiobookshelfConfigEntry,
@@ -93,59 +138,42 @@ async def async_setup_entry(
 
     coordinator = entry.runtime_data
 
-    sensors_descriptions: list[AudiobookShelfSensorEntityDescription] = []
-    sensors_descriptions.extend(SENSOR_DESCRIPTIONS)
-    # Populated by the first refresh, which has already run and would have
-    # aborted setup had it failed. Calling the API again here would be a second
-    # chance to fail, and a failure leaves the entry loaded with no entities at
-    # all - which also stops the coordinator polling, since it only schedules
-    # a refresh while it has listeners.
-    for library in coordinator.libraries:
-        sensors_descriptions.extend(
-            [
-                AudiobookShelfSensorEntityDescription(
-                    key="library_stats",
-                    key_context=library.id_,
-                    key_context_method="total_size",
-                    translation_key="library_size",
-                    translation_placeholders={"library": library.name},
-                    icon="mdi:harddisk",
-                    device_class=SensorDeviceClass.DATA_SIZE,
-                    state_class=SensorStateClass.MEASUREMENT,
-                    native_unit_of_measurement=UnitOfInformation.BYTES,
-                    suggested_unit_of_measurement=UnitOfInformation.GIGABYTES,
-                    suggested_display_precision=2,
-                ),
-                AudiobookShelfSensorEntityDescription(
-                    key="library_stats",
-                    key_context=library.id_,
-                    key_context_method="total_items",
-                    translation_key="library_items",
-                    translation_placeholders={"library": library.name},
-                    icon="mdi:book-multiple",
-                    state_class=SensorStateClass.MEASUREMENT,
-                    native_unit_of_measurement="items",
-                ),
-                AudiobookShelfSensorEntityDescription(
-                    key="library_stats",
-                    key_context=library.id_,
-                    key_context_method="total_duration",
-                    translation_key="library_duration",
-                    translation_placeholders={"library": library.name},
-                    icon="mdi:timer-outline",
-                    device_class=SensorDeviceClass.DURATION,
-                    state_class=SensorStateClass.MEASUREMENT,
-                    native_unit_of_measurement="s",
-                    suggested_unit_of_measurement="h",
-                    suggested_display_precision=0,
-                ),
-            ]
+    async_add_entities(
+        AudiobookShelfSensor(coordinator, entry, description)
+        for description in SENSOR_DESCRIPTIONS
+    )
+
+    known_libraries: set[str] = set()
+
+    @callback
+    def add_new_libraries() -> None:
+        """Create sensors for libraries seen for the first time."""
+        # coordinator.libraries is refreshed by library_stats() on every poll,
+        # and is populated by the first refresh before this platform is set up.
+        # Reading it rather than calling the API keeps platform setup off the
+        # network: a failure there leaves the entry loaded with no entities,
+        # which also stops polling, since the coordinator only schedules a
+        # refresh while it has listeners.
+        new = [
+            library
+            for library in coordinator.libraries
+            if library.id_ not in known_libraries
+        ]
+        if not new:
+            return
+        known_libraries.update(library.id_ for library in new)
+        _LOGGER.debug("Adding sensors for %s new librarie(s)", len(new))
+        async_add_entities(
+            AudiobookShelfSensor(coordinator, entry, description)
+            for library in new
+            for description in library_descriptions(library)
         )
-    entities = [
-        AudiobookShelfSensor(coordinator, entry, sensor_description)
-        for sensor_description in sensors_descriptions
-    ]
-    async_add_entities(entities)
+
+    add_new_libraries()
+    # A library created on the server was previously counted by
+    # count_libraries while never getting sensors of its own until the user
+    # reloaded the integration.
+    entry.async_on_unload(coordinator.async_add_listener(add_new_libraries))
 
 
 class AudiobookShelfSensor(CoordinatorEntity, SensorEntity):

--- a/info.md
+++ b/info.md
@@ -24,7 +24,7 @@
 | `sensor.audiobookshelf_<library>_duration`   | `sensor` | Total playable content in the library, shown in hours by default |
 | `sensor.audiobookshelf_<library>_size`       | `sensor` | Total disk space used by the library, shown in GB by default |
 
-Library sensors are created for the libraries that exist when the integration starts. Reload the integration after adding or removing a library on the server, otherwise the new library is counted by `sensor.audiobookshelf_libraries` without getting sensors of its own.
+A library created on the server gets its sensors automatically, at the next update. A library removed from the server leaves its sensors behind as `unavailable`; delete them from the entity registry if you want them gone.
 
 ## Actions
 

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -1,9 +1,10 @@
 """Tests for how sensors read values out of the coordinator's data."""
 
+import asyncio
 import json
 from pathlib import Path
 from types import SimpleNamespace
-from typing import Any
+from typing import TYPE_CHECKING, Any, cast
 from unittest.mock import MagicMock, patch
 
 from homeassistant.helpers.device_registry import DeviceEntryType
@@ -15,6 +16,9 @@ from custom_components.audiobookshelf.sensor import (
     AudiobookShelfSensor,
     AudiobookShelfSensorEntityDescription,
 )
+
+if TYPE_CHECKING:
+    from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 # Built per library at runtime, so they are not in SENSOR_DESCRIPTIONS.
 LIBRARY_TRANSLATION_KEYS = ("library_size", "library_items", "library_duration")
@@ -88,6 +92,75 @@ def test_identity_is_keyed_on_the_entry_not_the_url() -> None:
     # Was the integration version, which reads as the server version.
     assert "sw_version" not in sensor.device_info
     assert sensor.has_entity_name is True
+
+
+def _setup_platform(libraries: list[Any]) -> tuple[Any, list[Any], list[Any]]:
+    """Run the platform setup and return the coordinator, listeners and entities."""
+    listeners: list[Any] = []
+    entities: list[Any] = []
+
+    def _add_listener(callback_fn: Any, context: Any = None) -> Any:  # noqa: ARG001
+        """Record the listener the way DataUpdateCoordinator would."""
+        listeners.append(callback_fn)
+        return lambda: None
+
+    coordinator = MagicMock()
+    coordinator.api_url = "http://abs.local:13378"
+    coordinator.libraries = libraries
+    coordinator.async_add_listener = _add_listener
+
+    entry = MagicMock()
+    entry.entry_id = "entry-1"
+    entry.data = {}
+    entry.runtime_data = coordinator
+
+    asyncio.run(
+        sensor_module.async_setup_entry(
+            MagicMock(), entry, cast("AddEntitiesCallback", entities.extend)
+        )
+    )
+    return coordinator, listeners, entities
+
+
+def test_libraries_present_at_setup_get_sensors() -> None:
+    """Six global sensors plus three for the one library."""
+    _, _, entities = _setup_platform([SimpleNamespace(id_="lib-1", name="Books")])
+
+    assert len(entities) == len(SENSOR_DESCRIPTIONS) + 3
+
+
+def test_library_added_later_does_not_need_a_reload() -> None:
+    """count_libraries counted a new library while it had no sensors of its own."""
+    coordinator, listeners, entities = _setup_platform(
+        [SimpleNamespace(id_="lib-1", name="Books")]
+    )
+    before = len(entities)
+
+    coordinator.libraries.append(SimpleNamespace(id_="lib-2", name="Podcasts"))
+    for listener in listeners:
+        listener()
+
+    assert len(entities) == before + 3
+    new_ids = {e.unique_id for e in entities[before:]}
+    assert new_ids == {
+        "entry-1_library_stats_lib-2_total_size",
+        "entry-1_library_stats_lib-2_total_items",
+        "entry-1_library_stats_lib-2_total_duration",
+    }
+
+
+def test_unchanged_libraries_are_not_added_twice() -> None:
+    """The listener runs on every poll, so it has to be idempotent."""
+    _, listeners, entities = _setup_platform(
+        [SimpleNamespace(id_="lib-1", name="Books")]
+    )
+    before = len(entities)
+
+    for _ in range(3):
+        for listener in listeners:
+            listener()
+
+    assert len(entities) == before
 
 
 def _entity_translations() -> dict[str, Any]:


### PR DESCRIPTION
Stacked on #135, because it changes the documentation added there. Review
that one first.

Library sensors were built once during platform setup:

```python
for library in coordinator.libraries:
    sensors_descriptions.extend([...])
async_add_entities(entities)
```

So a library created on the server afterwards was counted by
`sensor.audiobookshelf_libraries` while never getting size, items or
duration sensors of its own. Nothing surfaced that, and nothing in the
docs mentioned it — the user had to work out that a reload was needed.

The platform now registers a coordinator listener that adds sensors for
library ids it has not seen. `coordinator.libraries` is refreshed by
`library_stats()` on every poll, so the data is already there; the
listener reads it rather than calling the API, which keeps platform setup
off the network for the reason recorded in CLAUDE.md.

The listener runs on every poll, so it has to be idempotent, and there is
a test for exactly that.

## Removal is deliberately not handled

A library that disappears from the server leaves its entities reporting
`unavailable`, via the availability guard added in #131. That is already
the correct outcome. Deleting entity registry entries on the user's
behalf during a routine update is not something I wanted to do silently,
and the registry is where a user would go to remove them deliberately.

Documented in both README and info.md rather than left implicit.

## Testing

50 tests, 3 new: that libraries present at setup get their sensors, that
a library appearing later gets them without a reload, and that repeated
polls do not add duplicates.

Negative control: dropping the `async_add_listener` registration fails
`test_library_added_later_does_not_need_a_reload` with `assert 9 == 12`,
and nothing else.

ruff, ruff format, mypy and pytest all clean.
