### PR TITLE
feat(config-flow): add options and reconfigure flows

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,9 @@ For more info on what the key can be used for see: https://api.audiobookshelf.or
 | `API key`       | The API key that you got in the previous step                                                             |
 | `Scan interval` | How regularly the data should be fetched from your Audiobookshelf instance (in seconds), defaults to 300s |
 
-Only one Audiobookshelf server can be configured at a time. To point the integration at a different server, remove the existing entry first.
+Only one Audiobookshelf server can be configured at a time.
+
+To change the address or replace the API key later, use **Reconfigure** on the integration rather than removing and re-adding it - that keeps your sensors and their history. The update interval is under **Configure**, and takes effect without a restart.
 
 ## Credits
 

--- a/custom_components/audiobookshelf/__init__.py
+++ b/custom_components/audiobookshelf/__init__.py
@@ -5,7 +5,7 @@ from collections.abc import Mapping
 from typing import Any
 
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import CONF_API_KEY, CONF_SCAN_INTERVAL, CONF_URL
+from homeassistant.const import CONF_API_KEY, CONF_URL
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers import device_registry as dr
@@ -13,7 +13,7 @@ from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.typing import ConfigType
 
 from .audiobook_shelf_data_update_coordinator import AudiobookShelfDataUpdateCoordinator
-from .const import DOMAIN, PLATFORMS
+from .const import DOMAIN, PLATFORMS, scan_interval_for
 from .services import async_setup_services
 
 type AudiobookshelfConfigEntry = ConfigEntry[AudiobookShelfDataUpdateCoordinator]
@@ -92,7 +92,7 @@ async def async_setup_entry(
     coordinator = AudiobookShelfDataUpdateCoordinator(
         hass,
         config_entry=entry,
-        scan_interval=int(entry.data[CONF_SCAN_INTERVAL]),
+        scan_interval=scan_interval_for(entry),
         api_url=entry.data[CONF_URL],
         token=entry.data[CONF_API_KEY],
     )
@@ -104,8 +104,19 @@ async def async_setup_entry(
 
     entry.runtime_data = coordinator
 
+    # The options flow only writes the entry; without this a changed scan
+    # interval would not take effect until Home Assistant restarted.
+    entry.async_on_unload(entry.add_update_listener(async_reload_entry))
+
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
     return True
+
+
+async def async_reload_entry(
+    hass: HomeAssistant, entry: AudiobookshelfConfigEntry
+) -> None:
+    """Reload the entry when its configuration changes."""
+    await hass.config_entries.async_reload(entry.entry_id)
 
 
 async def async_unload_entry(

--- a/custom_components/audiobookshelf/config_flow.py
+++ b/custom_components/audiobookshelf/config_flow.py
@@ -12,17 +12,26 @@ from aioaudiobookshelf.exceptions import AbsAuthError, AbsError, BadUserError
 from aiohttp import ClientError
 from homeassistant import config_entries
 from homeassistant.const import CONF_API_KEY, CONF_SCAN_INTERVAL, CONF_URL
+from homeassistant.core import callback
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
 if TYPE_CHECKING:
     from collections.abc import Mapping
 
-    from homeassistant.config_entries import ConfigFlowResult
+    from homeassistant.config_entries import ConfigEntry, ConfigFlowResult
     from homeassistant.core import HomeAssistant
 
-from .const import DOMAIN, REQUEST_TIMEOUT
+from .const import (
+    DEFAULT_SCAN_INTERVAL,
+    DOMAIN,
+    MIN_SCAN_INTERVAL,
+    REQUEST_TIMEOUT,
+    scan_interval_for,
+)
 
 _LOGGER = logging.getLogger(__name__)
+
+SCAN_INTERVAL_SELECTOR = vol.All(cv.positive_int, vol.Range(min=MIN_SCAN_INTERVAL))
 
 
 def validate_config(data: dict[str, Any]) -> dict:
@@ -101,8 +110,10 @@ class AudiobookshelfConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                             ): str,
                             vol.Optional(
                                 CONF_SCAN_INTERVAL,
-                                default=user_input.get(CONF_SCAN_INTERVAL, 300),
-                            ): cv.positive_int,
+                                default=user_input.get(
+                                    CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL
+                                ),
+                            ): SCAN_INTERVAL_SELECTOR,
                         }
                     ),
                     errors=errors,
@@ -113,7 +124,9 @@ class AudiobookshelfConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 data={
                     CONF_URL: user_input[CONF_URL],
                     CONF_API_KEY: user_input[CONF_API_KEY],
-                    CONF_SCAN_INTERVAL: user_input.get(CONF_SCAN_INTERVAL, 300),
+                    CONF_SCAN_INTERVAL: user_input.get(
+                        CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL
+                    ),
                 },
             )
 
@@ -124,7 +137,49 @@ class AudiobookshelfConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 {
                     vol.Required(CONF_URL): str,
                     vol.Required(CONF_API_KEY): str,
-                    vol.Optional(CONF_SCAN_INTERVAL, default=300): cv.positive_int,
+                    vol.Optional(
+                        CONF_SCAN_INTERVAL, default=DEFAULT_SCAN_INTERVAL
+                    ): SCAN_INTERVAL_SELECTOR,
+                }
+            ),
+            errors=errors,
+        )
+
+    @staticmethod
+    @callback
+    def async_get_options_flow(
+        config_entry: ConfigEntry,  # noqa: ARG004
+    ) -> AudiobookshelfOptionsFlow:
+        """Return the options flow handler."""
+        return AudiobookshelfOptionsFlow()
+
+    async def async_step_reconfigure(
+        self, user_input: dict[str, str] | None = None
+    ) -> ConfigFlowResult:
+        """Change the URL or API key without removing and re-adding the entry."""
+        reconfigure_entry = self._get_reconfigure_entry()
+        errors: dict = {}
+
+        if user_input is not None:
+            candidate = {**reconfigure_entry.data, **user_input}
+            errors.update(validate_config(candidate))
+            if not errors:
+                errors.update(await verify_config(self.hass, candidate))
+            if not errors:
+                return self.async_update_reload_and_abort(
+                    reconfigure_entry, data_updates=user_input
+                )
+
+        return self.async_show_form(
+            step_id="reconfigure",
+            data_schema=vol.Schema(
+                {
+                    vol.Required(
+                        CONF_URL, default=reconfigure_entry.data[CONF_URL]
+                    ): str,
+                    # Deliberately not pre-filled - the stored key is a
+                    # credential and there is nowhere sensible to show it.
+                    vol.Required(CONF_API_KEY): str,
                 }
             ),
             errors=errors,
@@ -159,4 +214,27 @@ class AudiobookshelfConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             step_id="reauth_confirm",
             data_schema=vol.Schema({vol.Required(CONF_API_KEY): str}),
             errors=errors,
+        )
+
+
+class AudiobookshelfOptionsFlow(config_entries.OptionsFlow):
+    """Let the poll interval be changed without re-adding the integration."""
+
+    async def async_step_init(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Handle the options."""
+        if user_input is not None:
+            return self.async_create_entry(data=user_input)
+
+        return self.async_show_form(
+            step_id="init",
+            data_schema=vol.Schema(
+                {
+                    vol.Required(
+                        CONF_SCAN_INTERVAL,
+                        default=scan_interval_for(self.config_entry),
+                    ): SCAN_INTERVAL_SELECTOR,
+                }
+            ),
         )

--- a/custom_components/audiobookshelf/const.py
+++ b/custom_components/audiobookshelf/const.py
@@ -1,14 +1,37 @@
 """Constants for the Audiobookshelf integration."""
 
+from typing import TYPE_CHECKING
+
 from aiohttp import ClientTimeout
-from homeassistant.const import Platform
+from homeassistant.const import CONF_SCAN_INTERVAL, Platform
+
+if TYPE_CHECKING:
+    from homeassistant.config_entries import ConfigEntry
 
 VERSION = "v0.3.0"
 DOMAIN = "audiobookshelf"
 PLATFORMS: list[Platform] = [Platform.SENSOR]
+
+DEFAULT_SCAN_INTERVAL = 300
+# A poll costs one request per library plus five more, so a very short
+# interval is a way to hammer your own server by accident.
+MIN_SCAN_INTERVAL = 30
 
 # aiohttp defaults to a five minute total timeout per request. A single poll
 # issues five requests plus one per library, so a server that accepts
 # connections but stops responding can hold a poll open for far longer than
 # the scan interval, with no error and no sign of staleness.
 REQUEST_TIMEOUT = ClientTimeout(total=30)
+
+
+def scan_interval_for(entry: "ConfigEntry") -> int:
+    """Return the poll interval, preferring options over the original data."""
+    # Entries created before the options flow existed only have the value in
+    # data, so both the setup path and the options form have to fall back the
+    # same way. Kept in one place so they cannot disagree.
+    return int(
+        entry.options.get(
+            CONF_SCAN_INTERVAL,
+            entry.data.get(CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL),
+        )
+    )

--- a/custom_components/audiobookshelf/translations/en.json
+++ b/custom_components/audiobookshelf/translations/en.json
@@ -15,6 +15,14 @@
                 "data": {
                     "api_key": "API Key"
                 }
+            },
+            "reconfigure": {
+                "title": "Reconfigure Audiobookshelf",
+                "description": "Point the integration at a different address, or replace the API key. Your sensors and their history are kept.",
+                "data": {
+                    "url": "API URL (starting with http:// or https://)",
+                    "api_key": "API Key"
+                }
             }
         },
         "error": {
@@ -28,7 +36,18 @@
         },
         "abort": {
             "already_configured": "Device is already configured",
-            "reauth_successful": "Re-authentication was successful"
+            "reauth_successful": "Re-authentication was successful",
+            "reconfigure_successful": "Reconfiguration was successful"
+        }
+    },
+    "options": {
+        "step": {
+            "init": {
+                "title": "Audiobookshelf options",
+                "data": {
+                    "scan_interval": "Update interval in seconds (minimum 30, defaults to 300s/5min)"
+                }
+            }
         }
     },
     "entity": {

--- a/info.md
+++ b/info.md
@@ -96,7 +96,9 @@ For more info on what the key can be used for see: https://api.audiobookshelf.or
 | `API key`       | The API key that you got in the previous step                                                             |
 | `Scan interval` | How regularly the data should be fetched from your Audiobookshelf instance (in seconds), defaults to 300s |
 
-Only one Audiobookshelf server can be configured at a time. To point the integration at a different server, remove the existing entry first.
+Only one Audiobookshelf server can be configured at a time.
+
+To change the address or replace the API key later, use **Reconfigure** on the integration rather than removing and re-adding it - that keeps your sensors and their history. The update interval is under **Configure**, and takes effect without a restart.
 
 ## Credits
 

--- a/tests/test_options_flow.py
+++ b/tests/test_options_flow.py
@@ -1,0 +1,84 @@
+"""Tests for reading the scan interval and for the options flow default."""
+
+import asyncio
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+import voluptuous as vol
+from homeassistant.const import CONF_SCAN_INTERVAL
+
+from custom_components.audiobookshelf.config_flow import (
+    SCAN_INTERVAL_SELECTOR,
+    AudiobookshelfOptionsFlow,
+)
+from custom_components.audiobookshelf.const import (
+    DEFAULT_SCAN_INTERVAL,
+    MIN_SCAN_INTERVAL,
+    scan_interval_for,
+)
+
+
+def _entry(data: dict[str, Any], options: dict[str, Any]) -> Any:
+    """Build a config entry stub with the given data and options."""
+    entry = MagicMock()
+    entry.data = data
+    entry.options = options
+    return entry
+
+
+def test_options_override_the_original_data() -> None:
+    """Changing the interval in options has to win over the setup value."""
+    entry = _entry({CONF_SCAN_INTERVAL: 300}, {CONF_SCAN_INTERVAL: 60})
+    assert scan_interval_for(entry) == 60
+
+
+def test_data_is_used_when_no_option_is_set() -> None:
+    """Entries created before the options flow existed only have data."""
+    entry = _entry({CONF_SCAN_INTERVAL: 120}, {})
+    assert scan_interval_for(entry) == 120
+
+
+def test_default_is_used_when_neither_is_set() -> None:
+    """Neither source is guaranteed, and a missing key used to raise."""
+    assert scan_interval_for(_entry({}, {})) == DEFAULT_SCAN_INTERVAL
+
+
+@pytest.mark.parametrize("interval", [0, 1, MIN_SCAN_INTERVAL - 1, -5])
+def test_intervals_below_the_floor_are_rejected(interval: int) -> None:
+    """A one second poll would hammer the server; cv.positive_int allowed it."""
+    with pytest.raises(vol.Invalid):
+        SCAN_INTERVAL_SELECTOR(interval)
+
+
+@pytest.mark.parametrize("interval", [MIN_SCAN_INTERVAL, 300, 3600])
+def test_sensible_intervals_are_accepted(interval: int) -> None:
+    """The floor must not reject ordinary values."""
+    assert SCAN_INTERVAL_SELECTOR(interval) == interval
+
+
+def test_options_form_defaults_to_the_current_interval() -> None:
+    """The form should open showing what is in force, not the built-in default."""
+    flow = AudiobookshelfOptionsFlow()
+    # OptionsFlow.config_entry returns _config_entry when it is set, otherwise
+    # it looks the entry up on hass. That shortcut is marked "for compatibility
+    # only - to be removed in 2025.12", so this line is what will need changing
+    # when the pinned Home Assistant moves past it. The integration itself only
+    # uses the public property and is unaffected.
+    flow._config_entry = _entry({CONF_SCAN_INTERVAL: 300}, {CONF_SCAN_INTERVAL: 45})  # noqa: SLF001
+    flow.async_show_form = MagicMock(return_value={})  # type: ignore[method-assign]
+
+    asyncio.run(flow.async_step_init())
+
+    schema = flow.async_show_form.call_args.kwargs["data_schema"]
+    assert schema({})[CONF_SCAN_INTERVAL] == 45
+
+
+def test_submitting_options_stores_them() -> None:
+    """The submitted value is written to entry options verbatim."""
+    flow = AudiobookshelfOptionsFlow()
+    flow.async_create_entry = MagicMock(return_value={})  # type: ignore[method-assign]
+
+    asyncio.run(flow.async_step_init({CONF_SCAN_INTERVAL: 90}))
+
+    flow.async_create_entry.assert_called_once_with(data={CONF_SCAN_INTERVAL: 90})


### PR DESCRIPTION
Stacked on #136, which is stacked on #135. Last of the review follow-ups.

## The problem

`scan_interval` was written into entry `data`, and the URL could not be
changed at all. The only way to adjust either was to remove the
integration and add it back, which loses every entity's recorder history.

Worse, that was also the exact move that used to destroy the existing
entry, before #131 declared `single_config_entry`. The lack of a
reconfigure flow was what made anyone reach for it.

## Reconfigure

Changes the URL or the API key on the existing entry, keeping its
entities and their history. Validates the candidate config the same way
the user step does before committing, then
`async_update_reload_and_abort`.

The API key field is deliberately not pre-filled. The stored value is a
credential and there is nowhere sensible to display it.

## Options

Changes the scan interval. The update listener added in `__init__.py` is
what makes it take effect without a restart - the options flow only
writes the entry.

Entries created before this only carry the interval in `data`, so
`scan_interval_for()` falls back options, then data, then default. Both
the setup path and the options form default read through it, so the two
cannot disagree. That fallback living in one place is the point; it is
exactly the "separate values drift silently" shape that CLAUDE.md already
warns about elsewhere.

Also gives the interval a 30 second floor. `cv.positive_int` accepted `1`,
which would poll a server that costs one request per library plus five
more, every second.

## Verified against the pinned Home Assistant

Rather than assuming these APIs exist at 2025.1.4:

- `SOURCE_RECONFIGURE` and `_get_reconfigure_entry()` (`config_entries.py:125`, `:3022`)
- `OptionsFlow.config_entry` (`:3133`), which returns `_config_entry` when
  set and otherwise looks the entry up on `hass`

That first branch is marked "for compatibility only - to be removed in
2025.12". The integration only uses the public property, so it is
unaffected either way, but one test sets `_config_entry` directly and
carries a comment saying so, since that is what will need changing when
the pin moves past it.

## Testing

62 tests, 12 new: the options-over-data-over-default fallback, the
interval floor accepting and rejecting either side of the boundary, that
the options form opens showing the interval currently in force rather
than the built-in default, and that a submitted value is stored verbatim.

ruff, ruff format, mypy and pytest all clean.

README and info.md now point at Reconfigure and Configure instead of
telling people to remove the entry.
