### PR TITLE
fix(migration): clear the stale sw_version and log the migration

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -192,7 +192,13 @@ These cost real time. All were hit in practice.
   nothing is. Verify with something independent, such as whether the port is still bound.
 - **`pycares` 5.x breaks `aiodns` 3.2.0** (`Channel.getaddrinfo()` signature change), which
   breaks every DNS lookup in Home Assistant and surfaces as a bare "Unknown error occurred"
-  in the config flow. Pinned via `pycares<5` in `requirements.txt`.
+  in the config flow. Pinned via `pycares<5` in `requirements.txt`. A one-off `uvx` command
+  that imports the Home Assistant stack needs `--with 'pycares<5'` too, or it hits this.
+- **`aiodns` refuses to run on Windows' default event loop.** `aiohttp` picks it as the
+  resolver whenever it is installed, so any script importing the Home Assistant stack on the
+  host dies with "aiodns needs a SelectorEventLoop on Windows" before doing anything. Call
+  `asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())` first. Home
+  Assistant itself only runs on Linux, so this is a host-scripting problem, not a real one.
 
 ## Dependencies
 
@@ -244,3 +250,23 @@ Anything that changes the shape of a unique ID from now on needs a matching bump
 in `async_migrate_entry`. The v1 migration is a pure prefix swap that keeps the rest of the key
 byte for byte, which is deliberate — it is far easier to verify than a reformat, and the
 trailing `_None_None` segments are invisible to users.
+
+### Verifying a migration against a real instance
+
+Install the *previous* release first, let it create its entities, then swap the component and
+restart. Two traps make this look broken when it is not:
+
+- **Registry writes during startup are deferred by 180 seconds.**
+  `helpers/registry.py` picks `SAVE_DELAY_LONG` (180) rather than `SAVE_DELAY` (10) whenever
+  `hass.state` is not `CoreState.running`, and a migration always runs before that. So
+  `.storage/core.entity_registry` keeps the *old* values for three minutes while the in-memory
+  registry is already correct — and restarting inside that window throws the change away.
+  `core.config_entries` saves on its own schedule and updates promptly, so the version bump
+  appearing without the entity rewrite is the expected intermediate state, not a failure.
+  Stop the container with a generous grace period (`podman stop --time 90`) to force the final
+  write, then read the file.
+- **Omitting a field from `DeviceInfo` does not clear it.** The device registry keeps whatever
+  is already stored, so removing `sw_version` only affects new installs. Clearing it for
+  existing ones takes an explicit `sw_version=None` in `async_update_device`. This was found
+  by testing the migration for real and is invisible to unit tests that only assert on what
+  the integration passes.

--- a/custom_components/audiobookshelf/__init__.py
+++ b/custom_components/audiobookshelf/__init__.py
@@ -60,7 +60,13 @@ def _migrate_url_identifiers(hass: HomeAssistant, entry: ConfigEntry) -> None:
     )
     if device is not None:
         device_registry.async_update_device(
-            device.id, new_identifiers={(DOMAIN, entry.entry_id)}
+            device.id,
+            new_identifiers={(DOMAIN, entry.entry_id)},
+            # v1 put the integration's own version here, where the device
+            # registry expects the server's. Dropping it from DeviceInfo does
+            # not clear what is already stored, so an upgraded install would
+            # keep showing it indefinitely.
+            sw_version=None,
         )
 
 
@@ -69,6 +75,7 @@ async def async_migrate_entry(
 ) -> bool:
     """Migrate an old config entry."""
     if entry.version == 1:
+        _LOGGER.info("Migrating Audiobookshelf entry from version 1 to 2")
         _migrate_url_identifiers(hass, entry)
         hass.config_entries.async_update_entry(entry, version=2)
     return True

--- a/tests/test_migration.py
+++ b/tests/test_migration.py
@@ -87,8 +87,17 @@ def test_device_identifiers_are_rekeyed() -> None:
     outcome = _migrate(_entry(), [], device=SimpleNamespace(id="dev-1"))
 
     outcome["devices"].assert_called_once_with(
-        "dev-1", new_identifiers={(DOMAIN, "entry-1")}
+        "dev-1", new_identifiers={(DOMAIN, "entry-1")}, sw_version=None
     )
+
+
+def test_stale_sw_version_is_cleared() -> None:
+    """Dropping a field from DeviceInfo does not clear what is stored."""
+    # v1 reported the integration's own version in sw_version, so without this
+    # an upgraded install keeps showing it on the device page forever.
+    outcome = _migrate(_entry(), [], device=SimpleNamespace(id="dev-1"))
+
+    assert outcome["devices"].call_args.kwargs["sw_version"] is None
 
 
 def test_missing_device_is_not_an_error() -> None:


### PR DESCRIPTION
Found during a live validation pass: Audiobookshelf 2.36.0 and Home
Assistant 2025.1.4 in Podman, installing the pre-#133 component first,
letting it create its entities, then swapping in current `main`.

## The bug

#133 dropped `sw_version` from `DeviceInfo` because it was reporting the
*integration's* `VERSION` in a field the device registry documents as the
device's own, so the device page implied it was the Audiobookshelf server
version.

That only fixes new installs. **The device registry keeps whatever is
already stored**, so omitting the field changes nothing for an existing
device — every upgrading user would have kept seeing `v0.3.0` forever.
Clearing it needs an explicit `sw_version=None` on `async_update_device`.

The unit tests could not have caught this: they assert on what the
integration passes, and the integration was passing the right thing. Only
a real registry shows the field surviving.

## Verification

Restored the registry to its v1 shape, staged the fixed component, and
re-ran the migration end to end. Before the fix, 9 of 10 checks passed
with `sw_version` still `'v0.3.0'`. After:

```
[PASS] config entry at version 2
[PASS] same 12 entity_ids -- 12 -> 12
[PASS] registry row ids unchanged (history preserved)
[PASS] unique_ids rekeyed onto entry id
[PASS] suffixes byte-identical
[PASS] exactly one device
[PASS] device rekeyed onto entry id
[PASS] entry_type is service
[PASS] stale sw_version cleared -- None
```

Sample rewrite, confirmed against the live registry:

```
sensor.audiobookshelf_users
  before  http://abs-test_count_users_None_None
  after   01KYPP34D88RXYTZT68Q4WKFN0_count_users_None_None
```

63 tests, one new asserting `sw_version=None` reaches
`async_update_device`. ruff, ruff format and mypy clean.

## Migration logging

Home Assistant logs nothing of its own when an integration migrates, and
this one was silent too, so a log gave no way to tell whether the
migration had run. Now logged at info. That absence directly cost time
diagnosing the above.

## Two traps recorded in CLAUDE.md

Both cost real time in this pass and would cost the next person the same.

**Registry writes during startup are deferred 180 seconds.**
`helpers/registry.py:77` picks `SAVE_DELAY_LONG` (180) over `SAVE_DELAY`
(10) whenever `hass.state` is not `CoreState.running` — which a migration
never is. So `.storage/core.entity_registry` holds the *old* values for
three minutes while the in-memory registry is already correct, and
restarting inside that window throws the change away. `core.config_entries`
saves on its own schedule and updates promptly, so seeing the version bump
land without the entity rewrite is the expected intermediate state, not a
failure. I read it as a failure at first; the note should stop that
repeating.

**`aiodns` will not run on Windows' default event loop.** `aiohttp` selects
it as resolver whenever installed, so any host script importing the Home
Assistant stack dies immediately. Needs
`asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())`.
Also noted that a one-off `uvx` command needs `--with 'pycares<5'`, since
the pin only lives in `requirements.txt` — without it you hit the exact
`Channel.getaddrinfo()` breakage the file already warns about.
