### PR TITLE
chore(release): 0.4.0

### DIFF
--- a/custom_components/audiobookshelf/const.py
+++ b/custom_components/audiobookshelf/const.py
@@ -8,7 +8,7 @@ from homeassistant.const import CONF_SCAN_INTERVAL, Platform
 if TYPE_CHECKING:
     from homeassistant.config_entries import ConfigEntry
 
-VERSION = "v0.3.0"
+VERSION = "v0.4.0"
 DOMAIN = "audiobookshelf"
 PLATFORMS: list[Platform] = [Platform.SENSOR]
 

--- a/custom_components/audiobookshelf/manifest.json
+++ b/custom_components/audiobookshelf/manifest.json
@@ -17,5 +17,5 @@
     "aioaudiobookshelf>=0.1.24,<0.2"
   ],
   "single_config_entry": true,
-  "version": "0.3.0"
+  "version": "0.4.0"
 }


### PR DESCRIPTION
Version bump only. Both places, per CLAUDE.md:

- `const.py` -> `VERSION = "v0.4.0"`
- `manifest.json` -> `"version": "0.4.0"`

`hacs.json` is unchanged: nothing in this release raises the minimum Home
Assistant version, which stays at 2025.1.4.

## Why 0.4.0 rather than 1.0.0

This line is 0.x and the release contains a breaking change (#133), which
under semver for 0.x is a minor bump. 1.0.0 is available if you would
rather use this release to signal stability — say so and I will redo the
bump.

## The release gate has never run

`release.yml` gained a version-consistency check in #134 and no release
has been cut since, so it has never executed. I extracted the script
verbatim from the workflow and ran it against this tree:

```
=== correct tag v0.4.0 (expect exit 0) ===
exit=0
=== stale tag v0.3.0 (expect exit 1) ===
::error::const.py VERSION is v0.4.0, tag is v0.3.0
::error::manifest.json version is 0.4.0, tag is v0.3.0
exit=1
=== tag without v prefix (expect exit 1) ===
::error::const.py VERSION is v0.4.0, tag is 0.4.0
exit=1
```

It passes on a correct tag and fails on both a stale one and a missing
`v` prefix, so tagging `v0.4.0` will get through and a mistyped tag will
not.

ruff, ruff format, mypy and 63 tests all clean.

## Note for whoever publishes the release

The workflow attaches `Audiobookshelf_v0.4.0.zip`, but that asset is
**not** what HACS installs - `hacs.json` sets no `zip_release`, so HACS
pulls the individual files at the tag. The archive serves the manual
install path in the README. CLAUDE.md said the opposite until #135
corrected it.
