### PR TITLE
feat(sensor): report the Audiobookshelf server version on the device

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,6 +39,18 @@ the `remove_my_progress` service.
 | `GET /api/libraries/{id}/items` | service | paginated |
 | `GET`/`DELETE /api/me/progress/...` | service | |
 
+`POST /api/authorize` is not in the table because the library calls it, not this integration —
+`get_admin_client_by_token` posts it to build the client. Its response carries
+`serverSettings.version`, which the library exposes as `client.server_settings.version`. That is
+where the device's `sw_version` comes from, so it costs no request of its own. It is only
+refreshed when the client is rebuilt, so a server upgrade is not reflected until the entry
+reloads.
+
+Audiobookshelf exposes **no update-check endpoint**. `/api/check-for-update`, `/api/update`,
+`/api/version` and `/api/server-settings` all 404 on 2.36.0; the web UI queries GitHub from the
+browser. Anything reporting "an update is available" has to ask GitHub directly, which is why
+this integration does not do it today.
+
 `/api/libraries/{id}/stats` omits `totalAuthors` for **podcast** libraries. `LibraryStats.total_authors`
 must stay `int | None`. This is not hypothetical — it was confirmed against a real server
 with a podcast library, and a required field there would break every poll.

--- a/custom_components/audiobookshelf/audiobook_shelf_data_update_coordinator.py
+++ b/custom_components/audiobookshelf/audiobook_shelf_data_update_coordinator.py
@@ -104,6 +104,7 @@ class AudiobookShelfDataUpdateCoordinator(DataUpdateCoordinator):
         self.api_url = api_url
         self.token = token
         self.libraries: list[Library] = []
+        self.server_version: str | None = None
 
         super().__init__(
             hass,
@@ -127,6 +128,11 @@ class AudiobookShelfDataUpdateCoordinator(DataUpdateCoordinator):
                     timeout=REQUEST_TIMEOUT,
                 ),
             )
+            # /api/authorize is already called to build the client and its
+            # response carries the server version, so this costs no extra
+            # request. It is only refreshed when the client is rebuilt, which
+            # is fine for something shown on the device page.
+            self.server_version = self._client.server_settings.version
         return self._client
 
     async def get_libraries(self) -> list[Library]:

--- a/custom_components/audiobookshelf/sensor.py
+++ b/custom_components/audiobookshelf/sensor.py
@@ -205,6 +205,7 @@ class AudiobookShelfSensor(CoordinatorEntity, SensorEntity):
             entry_type=DeviceEntryType.SERVICE,
             name="Audiobookshelf",
             manufacturer="advplyr",
+            sw_version=coordinator.server_version,
             configuration_url=coordinator.api_url,
         )
 

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -80,6 +80,7 @@ def test_identity_is_keyed_on_the_entry_not_the_url() -> None:
     """The URL is user-editable, so identity derived from it orphans entities."""
     coordinator = MagicMock()
     coordinator.api_url = "http://abs.local:13378"
+    coordinator.server_version = "2.36.0"
     entry = MagicMock()
     entry.entry_id = "entry-1"
 
@@ -89,9 +90,35 @@ def test_identity_is_keyed_on_the_entry_not_the_url() -> None:
     assert sensor.device_info is not None
     assert sensor.device_info["identifiers"] == {(DOMAIN, "entry-1")}
     assert sensor.device_info["entry_type"] is DeviceEntryType.SERVICE
-    # Was the integration version, which reads as the server version.
-    assert "sw_version" not in sensor.device_info
     assert sensor.has_entity_name is True
+
+
+def test_sw_version_reports_the_server_not_the_integration() -> None:
+    """It used to report the integration's own VERSION constant."""
+    coordinator = MagicMock()
+    coordinator.api_url = "http://abs.local:13378"
+    coordinator.server_version = "2.36.0"
+    entry = MagicMock()
+    entry.entry_id = "entry-1"
+
+    sensor = AudiobookShelfSensor(coordinator, entry, LIBRARY_SENSOR)
+
+    assert sensor.device_info is not None
+    assert sensor.device_info["sw_version"] == "2.36.0"
+
+
+def test_sw_version_absent_before_the_first_client_is_built() -> None:
+    """A server too old to report it must not break entity creation."""
+    coordinator = MagicMock()
+    coordinator.api_url = "http://abs.local:13378"
+    coordinator.server_version = None
+    entry = MagicMock()
+    entry.entry_id = "entry-1"
+
+    sensor = AudiobookShelfSensor(coordinator, entry, LIBRARY_SENSOR)
+
+    assert sensor.device_info is not None
+    assert sensor.device_info["sw_version"] is None
 
 
 def _setup_platform(libraries: list[Any]) -> tuple[Any, list[Any], list[Any]]:


### PR DESCRIPTION
Follow-up to #139, which cleared `sw_version` rather than populating it.

#133 dropped `sw_version` because it was reporting the *integration's*
`VERSION` in a field the device registry defines as the device's own, so
the device page implied it was the Audiobookshelf server version. #139
then cleared the stale value from existing installs. That left the field
empty, which is honest but not useful.

## The real version is already on hand

`get_admin_client_by_token` posts `/api/authorize` to build the client,
and that response carries `serverSettings.version`, which the library
exposes as `client.server_settings.version` (`schema/server.py:76`,
`client/_base.py:29`). Capturing it where the client is built costs **no
extra request**.

It only refreshes when the client is rebuilt, so a server upgrade is not
reflected until the entry reloads. That is a deliberate trade: the
alternative is polling `/status` every cycle to keep a device-page field
current, which is not worth a request per poll. Noted in CLAUDE.md.

## Verified against a live server

Against the Audiobookshelf 2.36.0 container:

```
before first poll : server_version = None
after  first poll : server_version = 2.36.0
libraries fetched : ['Books', 'Shows']

PASS: matches the running server (2.36.0), no extra request made
```

65 tests, two new: that `sw_version` carries the server version, and that
a `None` version does not break entity creation.

## On issue #17

While looking into this I probed what Audiobookshelf actually offers, and
it has **no update-check endpoint**: `/api/check-for-update`,
`/api/update`, `/api/version` and `/api/server-settings` all 404 on
2.36.0. The web UI queries GitHub from the browser.

So "is an update available" cannot be answered from the server alone, and
this PR does not attempt it — it only makes the installed version
visible, which is the half that can be done locally. The constraint is now
recorded in CLAUDE.md so it does not have to be rediscovered.
