### PR TITLE
feat(update): add an opt-in check for new Audiobookshelf releases

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,12 @@
 
 A library created on the server gets its sensors automatically, at the next update. A library removed from the server leaves its sensors behind as `unavailable`; delete them from the entity registry if you want them gone.
 
+## Optional: update notifications
+
+Audiobookshelf does not report available updates through its own API, so this is **off by default**. Turning on **Check GitHub for new Audiobookshelf releases** under **Configure** adds an `update.audiobookshelf_server` entity that compares the version your server reports against the latest published release, checking once an hour.
+
+This is the only thing the integration does that leaves your network. Left off, no update entity is created and no external request is ever made.
+
 ## Actions
 
 ### `audiobookshelf.remove_my_progress`

--- a/custom_components/audiobookshelf/audiobook_shelf_data_update_coordinator.py
+++ b/custom_components/audiobookshelf/audiobook_shelf_data_update_coordinator.py
@@ -135,6 +135,17 @@ class AudiobookShelfDataUpdateCoordinator(DataUpdateCoordinator):
             self.server_version = self._client.server_settings.version
         return self._client
 
+    async def async_refresh_server_version(self) -> str | None:
+        """Re-read the server version by rebuilding the client."""
+        # The version only arrives with /api/authorize, which is what building
+        # the client does, so there is nowhere else to read it from without
+        # relying on serverVersion in /status, which is undocumented. Dropping
+        # the cached client is safe: anything mid-flight holds its own
+        # reference, and the next call rebuilds.
+        self._client = None
+        await self.get_client()
+        return self.server_version
+
     async def get_libraries(self) -> list[Library]:
         """Fetch library id list from API."""
         return await (await self.get_client()).get_all_libraries()  # type: ignore[no-any-return]

--- a/custom_components/audiobookshelf/config_flow.py
+++ b/custom_components/audiobookshelf/config_flow.py
@@ -22,10 +22,12 @@ if TYPE_CHECKING:
     from homeassistant.core import HomeAssistant
 
 from .const import (
+    CONF_CHECK_FOR_UPDATES,
     DEFAULT_SCAN_INTERVAL,
     DOMAIN,
     MIN_SCAN_INTERVAL,
     REQUEST_TIMEOUT,
+    check_for_updates_for,
     scan_interval_for,
 )
 
@@ -235,6 +237,12 @@ class AudiobookshelfOptionsFlow(config_entries.OptionsFlow):
                         CONF_SCAN_INTERVAL,
                         default=scan_interval_for(self.config_entry),
                     ): SCAN_INTERVAL_SELECTOR,
+                    # Off by default. This is the only thing the integration
+                    # does that leaves the local network.
+                    vol.Required(
+                        CONF_CHECK_FOR_UPDATES,
+                        default=check_for_updates_for(self.config_entry),
+                    ): cv.boolean,
                 }
             ),
         )

--- a/custom_components/audiobookshelf/const.py
+++ b/custom_components/audiobookshelf/const.py
@@ -10,7 +10,7 @@ if TYPE_CHECKING:
 
 VERSION = "v0.4.0"
 DOMAIN = "audiobookshelf"
-PLATFORMS: list[Platform] = [Platform.SENSOR]
+PLATFORMS: list[Platform] = [Platform.SENSOR, Platform.UPDATE]
 
 DEFAULT_SCAN_INTERVAL = 300
 # A poll costs one request per library plus five more, so a very short
@@ -22,6 +22,22 @@ MIN_SCAN_INTERVAL = 30
 # connections but stops responding can hold a poll open for far longer than
 # the scan interval, with no error and no sign of staleness.
 REQUEST_TIMEOUT = ClientTimeout(total=30)
+
+# Audiobookshelf exposes no update-check endpoint of its own - all 112
+# documented endpoints were checked - so the only way to answer "is there a
+# newer version" is to ask GitHub, as the web UI does from the browser. That
+# is the one thing this integration does that leaves the local network, so it
+# is off unless the user turns it on.
+CONF_CHECK_FOR_UPDATES = "check_for_updates"
+DEFAULT_CHECK_FOR_UPDATES = False
+GITHUB_LATEST_RELEASE_URL = (
+    "https://api.github.com/repos/advplyr/audiobookshelf/releases/latest"
+)
+
+
+def check_for_updates_for(entry: "ConfigEntry") -> bool:
+    """Return whether the user has opted in to the GitHub release check."""
+    return bool(entry.options.get(CONF_CHECK_FOR_UPDATES, DEFAULT_CHECK_FOR_UPDATES))
 
 
 def scan_interval_for(entry: "ConfigEntry") -> int:

--- a/custom_components/audiobookshelf/entity.py
+++ b/custom_components/audiobookshelf/entity.py
@@ -1,0 +1,23 @@
+"""Shared entity plumbing for the Audiobookshelf integration."""
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.helpers.device_registry import DeviceEntryType, DeviceInfo
+
+from .audiobook_shelf_data_update_coordinator import AudiobookShelfDataUpdateCoordinator
+from .const import DOMAIN
+
+
+def device_info_for(
+    entry: ConfigEntry, coordinator: AudiobookShelfDataUpdateCoordinator
+) -> DeviceInfo:
+    """Describe the server that every entity in this integration belongs to."""
+    # Shared rather than repeated per platform: two entities disagreeing on
+    # the identifiers would register two devices for the one server.
+    return DeviceInfo(
+        identifiers={(DOMAIN, entry.entry_id)},
+        entry_type=DeviceEntryType.SERVICE,
+        name="Audiobookshelf",
+        manufacturer="advplyr",
+        sw_version=coordinator.server_version,
+        configuration_url=coordinator.api_url,
+    )

--- a/custom_components/audiobookshelf/sensor.py
+++ b/custom_components/audiobookshelf/sensor.py
@@ -13,7 +13,6 @@ from homeassistant.components.sensor import (
 )
 from homeassistant.const import UnitOfInformation
 from homeassistant.core import HomeAssistant, callback
-from homeassistant.helpers.device_registry import DeviceEntryType, DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
@@ -21,7 +20,7 @@ from custom_components.audiobookshelf import AudiobookshelfConfigEntry, clean_co
 from custom_components.audiobookshelf.audiobook_shelf_data_update_coordinator import (
     AudiobookShelfDataUpdateCoordinator,
 )
-from custom_components.audiobookshelf.const import DOMAIN
+from custom_components.audiobookshelf.entity import device_info_for
 
 _LOGGER = getLogger(__name__)
 
@@ -200,14 +199,7 @@ class AudiobookShelfSensor(CoordinatorEntity, SensorEntity):
             f"_{sensor_description.key_context}"
             f"_{sensor_description.key_context_method}"
         )
-        self._attr_device_info = DeviceInfo(
-            identifiers={(DOMAIN, entry.entry_id)},
-            entry_type=DeviceEntryType.SERVICE,
-            name="Audiobookshelf",
-            manufacturer="advplyr",
-            sw_version=coordinator.server_version,
-            configuration_url=coordinator.api_url,
-        )
+        self._attr_device_info = device_info_for(entry, coordinator)
 
     @property
     def available(self) -> bool:

--- a/custom_components/audiobookshelf/translations/en.json
+++ b/custom_components/audiobookshelf/translations/en.json
@@ -45,7 +45,11 @@
             "init": {
                 "title": "Audiobookshelf options",
                 "data": {
-                    "scan_interval": "Update interval in seconds (minimum 30, defaults to 300s/5min)"
+                    "scan_interval": "Update interval in seconds (minimum 30, defaults to 300s/5min)",
+                    "check_for_updates": "Check GitHub for new Audiobookshelf releases"
+                },
+                "data_description": {
+                    "check_for_updates": "Audiobookshelf does not report available updates itself, so this asks GitHub once an hour. It is the only thing this integration does that leaves your network, and it is off by default."
                 }
             }
         }
@@ -78,6 +82,11 @@
             },
             "library_duration": {
                 "name": "{library} duration"
+            }
+        },
+        "update": {
+            "server": {
+                "name": "Server"
             }
         }
     },

--- a/custom_components/audiobookshelf/update.py
+++ b/custom_components/audiobookshelf/update.py
@@ -1,0 +1,122 @@
+"""Update platform reporting whether a newer Audiobookshelf server exists."""
+
+from datetime import timedelta
+from logging import getLogger
+
+from aioaudiobookshelf.exceptions import AbsError
+from aiohttp import ClientError
+from homeassistant.components.update import UpdateDeviceClass, UpdateEntity
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.aiohttp_client import async_get_clientsession
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from custom_components.audiobookshelf import AudiobookshelfConfigEntry
+from custom_components.audiobookshelf.audiobook_shelf_data_update_coordinator import (
+    AudiobookShelfDataUpdateCoordinator,
+)
+from custom_components.audiobookshelf.const import (
+    GITHUB_LATEST_RELEASE_URL,
+    REQUEST_TIMEOUT,
+    check_for_updates_for,
+)
+from custom_components.audiobookshelf.entity import device_info_for
+
+_LOGGER = getLogger(__name__)
+
+# GitHub allows 60 unauthenticated requests an hour per address and releases
+# appear a few times a month, so hourly is generous either way. This is
+# deliberately separate from the sensor poll: the release check is the one
+# thing here that leaves the local network, and it must not be able to hold
+# up or fail a poll of the user's own server.
+SCAN_INTERVAL = timedelta(hours=1)
+PARALLEL_UPDATES = 0
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,  # noqa: ARG001
+    entry: AudiobookshelfConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up the update platform, when the user has opted in."""
+    if not check_for_updates_for(entry):
+        # The platform is forwarded either way so that unloading always
+        # matches what was set up. Opting out simply creates no entity.
+        _LOGGER.debug("Update checking is disabled, not adding an update entity")
+        return
+
+    async_add_entities([AudiobookshelfUpdate(entry.runtime_data, entry)], True)  # noqa: FBT003
+
+
+class AudiobookshelfUpdate(UpdateEntity):
+    """Compares the running server against the newest published release."""
+
+    _attr_has_entity_name = True
+    _attr_translation_key = "server"
+    _attr_device_class = UpdateDeviceClass.FIRMWARE
+
+    def __init__(
+        self,
+        coordinator: AudiobookShelfDataUpdateCoordinator,
+        entry: AudiobookshelfConfigEntry,
+    ) -> None:
+        """Initialize the update entity."""
+        self.coordinator = coordinator
+        self._attr_unique_id = f"{entry.entry_id}_server_update"
+        self._attr_device_info = device_info_for(entry, coordinator)
+
+    @property
+    def installed_version(self) -> str | None:
+        """Return the version the server is running."""
+        return self.coordinator.server_version
+
+    @property
+    def release_url(self) -> str | None:
+        """Link to the release notes for the newest version."""
+        if self.latest_version is None:
+            return None
+        return (
+            "https://github.com/advplyr/audiobookshelf/releases/tag/"
+            f"v{self.latest_version}"
+        )
+
+    async def async_update(self) -> None:
+        """Refresh both halves of the comparison."""
+        # The installed version is cached on the coordinator and otherwise only
+        # re-read when the client is rebuilt, so without this the entity would
+        # go on offering an update the user had already applied.
+        try:
+            await self.coordinator.async_refresh_server_version()
+        except AbsError as err:
+            _LOGGER.debug("Could not re-read the server version: %s", err)
+
+        latest = await self._async_latest_release()
+        if latest is not None:
+            # Keep the last good answer rather than dropping to unknown, so a
+            # momentary GitHub failure does not blank the entity.
+            self._attr_latest_version = latest
+
+    async def _async_latest_release(self) -> str | None:
+        """Ask GitHub for the newest release, or None if it cannot be reached."""
+        session = async_get_clientsession(self.hass)
+        try:
+            async with session.get(
+                GITHUB_LATEST_RELEASE_URL,
+                headers={"Accept": "application/vnd.github+json"},
+                timeout=REQUEST_TIMEOUT,
+            ) as response:
+                response.raise_for_status()
+                body = await response.json()
+        except (ClientError, TimeoutError) as err:
+            _LOGGER.warning("Could not reach GitHub to check for updates: %s", err)
+            return None
+        except (ValueError, LookupError) as err:
+            _LOGGER.warning("Unexpected response from the GitHub API: %s", err)
+            return None
+
+        tag = body.get("tag_name") if isinstance(body, dict) else None
+        if not isinstance(tag, str) or not tag:
+            _LOGGER.warning("GitHub release response carried no usable tag_name")
+            return None
+
+        # Releases are tagged v2.36.0 while the server reports 2.36.0.
+        return tag.removeprefix("v")

--- a/info.md
+++ b/info.md
@@ -26,6 +26,12 @@
 
 A library created on the server gets its sensors automatically, at the next update. A library removed from the server leaves its sensors behind as `unavailable`; delete them from the entity registry if you want them gone.
 
+## Optional: update notifications
+
+Audiobookshelf does not report available updates through its own API, so this is **off by default**. Turning on **Check GitHub for new Audiobookshelf releases** under **Configure** adds an `update.audiobookshelf_server` entity that compares the version your server reports against the latest published release, checking once an hour.
+
+This is the only thing the integration does that leaves your network. Left off, no update entity is created and no external request is ever made.
+
 ## Actions
 
 ### `audiobookshelf.remove_my_progress`

--- a/tests/test_update.py
+++ b/tests/test_update.py
@@ -1,0 +1,163 @@
+"""Tests for the opt-in GitHub release check."""
+
+import asyncio
+from contextlib import asynccontextmanager
+from typing import TYPE_CHECKING, Any, cast
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from aiohttp import ClientError
+from homeassistant.const import CONF_SCAN_INTERVAL
+
+from custom_components.audiobookshelf import update as update_module
+from custom_components.audiobookshelf.const import (
+    CONF_CHECK_FOR_UPDATES,
+    check_for_updates_for,
+)
+from custom_components.audiobookshelf.update import (
+    AudiobookshelfUpdate,
+    async_setup_entry,
+)
+
+if TYPE_CHECKING:
+    from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+
+def _entry(options: dict[str, Any] | None = None) -> Any:
+    """Build a config entry stub carrying the given options."""
+    coordinator = MagicMock()
+    coordinator.api_url = "http://abs.local:13378"
+    coordinator.server_version = "2.36.0"
+    coordinator.async_refresh_server_version = AsyncMock(return_value="2.36.0")
+
+    entry = MagicMock()
+    entry.entry_id = "entry-1"
+    entry.options = options if options is not None else {}
+    entry.runtime_data = coordinator
+    return entry
+
+
+def _github_returning(payload: Any, *, error: Exception | None = None) -> Any:
+    """Build a session whose GitHub call yields payload, or raises."""
+
+    @asynccontextmanager
+    async def _get(*_args: Any, **_kwargs: Any) -> Any:
+        if error is not None:
+            raise error
+        response = MagicMock()
+        response.raise_for_status = MagicMock()
+        response.json = AsyncMock(return_value=payload)
+        yield response
+
+    session = MagicMock()
+    session.get = _get
+    return session
+
+
+def _updated(entity: AudiobookshelfUpdate, session: Any) -> None:
+    """Run one poll of the entity against the given session."""
+    entity.hass = MagicMock()
+    with patch.object(update_module, "async_get_clientsession", return_value=session):
+        asyncio.run(entity.async_update())
+
+
+def test_disabled_by_default() -> None:
+    """The GitHub check is the one thing that leaves the network."""
+    assert check_for_updates_for(_entry()) is False
+
+
+def test_enabled_when_the_option_is_set() -> None:
+    """The options flow toggle is what turns it on."""
+    assert check_for_updates_for(_entry({CONF_CHECK_FOR_UPDATES: True})) is True
+
+
+def test_no_entity_created_when_disabled() -> None:
+    """The platform is always forwarded, so opting out must add nothing."""
+    added: list[Any] = []
+    entry = _entry({CONF_SCAN_INTERVAL: 300})
+
+    add = cast("AddEntitiesCallback", lambda e, _=False: added.extend(e))
+    asyncio.run(async_setup_entry(MagicMock(), entry, add))
+
+    assert added == []
+
+
+def test_entity_created_when_enabled() -> None:
+    """Opting in creates exactly one update entity."""
+    added: list[Any] = []
+    entry = _entry({CONF_CHECK_FOR_UPDATES: True})
+
+    add = cast("AddEntitiesCallback", lambda e, _=False: added.extend(e))
+    asyncio.run(async_setup_entry(MagicMock(), entry, add))
+
+    assert len(added) == 1
+    assert added[0].unique_id == "entry-1_server_update"
+
+
+def test_tag_prefix_is_stripped() -> None:
+    """Releases are tagged v2.37.0 while the server reports 2.37.0."""
+    entry = _entry({CONF_CHECK_FOR_UPDATES: True})
+    entity = AudiobookshelfUpdate(entry.runtime_data, entry)
+
+    _updated(entity, _github_returning({"tag_name": "v2.37.0"}))
+
+    assert entity.latest_version == "2.37.0"
+    assert entity.installed_version == "2.36.0"
+    assert entity.release_url == (
+        "https://github.com/advplyr/audiobookshelf/releases/tag/v2.37.0"
+    )
+
+
+def test_matching_versions_report_no_update() -> None:
+    """Up to date is the common case and must not offer an update."""
+    entry = _entry({CONF_CHECK_FOR_UPDATES: True})
+    entity = AudiobookshelfUpdate(entry.runtime_data, entry)
+
+    _updated(entity, _github_returning({"tag_name": "v2.36.0"}))
+
+    assert entity.latest_version == entity.installed_version == "2.36.0"
+
+
+def test_installed_version_is_re_read_each_poll() -> None:
+    """Otherwise the entity offers an update the user has already applied."""
+    entry = _entry({CONF_CHECK_FOR_UPDATES: True})
+    coordinator = entry.runtime_data
+    entity = AudiobookshelfUpdate(coordinator, entry)
+
+    _updated(entity, _github_returning({"tag_name": "v2.37.0"}))
+
+    assert coordinator.async_refresh_server_version.call_count == 1
+
+
+@pytest.mark.parametrize(
+    ("payload", "error"),
+    [
+        pytest.param(None, ClientError("no route"), id="github-unreachable"),
+        pytest.param(None, TimeoutError(), id="github-timeout"),
+        pytest.param({"message": "rate limited"}, None, id="no-tag-name"),
+        pytest.param(["unexpected"], None, id="not-an-object"),
+    ],
+)
+def test_github_failures_keep_the_last_known_answer(
+    payload: Any, error: Exception | None
+) -> None:
+    """A GitHub blip must not blank the entity, nor touch anything else."""
+    entry = _entry({CONF_CHECK_FOR_UPDATES: True})
+    entity = AudiobookshelfUpdate(entry.runtime_data, entry)
+
+    _updated(entity, _github_returning({"tag_name": "v2.37.0"}))
+    assert entity.latest_version == "2.37.0"
+
+    _updated(entity, _github_returning(payload, error=error))
+
+    assert entity.latest_version == "2.37.0"
+    assert entity.installed_version == "2.36.0"
+
+
+def test_release_url_is_none_before_the_first_answer() -> None:
+    """Nothing to link to until GitHub has been reached once."""
+    entry = _entry({CONF_CHECK_FOR_UPDATES: True})
+    entity = AudiobookshelfUpdate(entry.runtime_data, entry)
+
+    assert entity.latest_version is None
+    assert entity.release_url is None


### PR DESCRIPTION
Closes #17. Stacked on #141, which supplies the installed version.

## Why it has to ask GitHub

You asked me to check the official API reference rather than trust my
endpoint probing, so I did. Of the **112 documented endpoints**, the only
matches for update/version/check/release are `GET /healthcheck`,
`PATCH /api/me/progress/batch/update` and `POST /api/items/batch/update` —
none of them an update check. The complete non-`/api` surface is `/auth`,
`/healthcheck`, `/ping`, `/status`, `/init`, `/login`, `/logout`.

So Audiobookshelf genuinely cannot answer this. The web UI queries GitHub
from the browser, which is why the server never needed to.

Two other things fell out of reading the docs:

- `serverVersion` in `/status` is **undocumented** — the reference lists
  only `isInit`, `language`, `ConfigPath`, `MetadataPath`, though 2.36.0
  returns it.
- `serverSettings.version` **is** documented, in the authorize/login
  response schema. That is what #141 uses, so it turns out to be the
  documented source as well as the free one.

## Opt-in

The GitHub call is the only thing this integration does that leaves the
local network, so it sits behind an options-flow toggle defaulting to
**off**. With it off no entity is created and no request is made.

The update platform is forwarded either way and the entity is simply not
added when disabled, so unloading always matches what was set up — the
alternative, varying the forwarded platform list, leaks a platform when
the option is turned off and the entry reloads.

## Isolation

- Hourly on the platform's own `SCAN_INTERVAL`, not the sensor poll.
- A GitHub failure keeps the last known answer rather than blanking the
  entity, and never touches the sensors.
- Unreachable, timed out, non-JSON, and missing/`tag_name`-less responses
  are all handled and logged.

## Installed version has to be re-read

`server_version` is cached on the coordinator and otherwise only refreshed
when the client is rebuilt. Without re-reading it the entity would go on
offering an update the user had already applied, forever. Each check now
calls `async_refresh_server_version()` first.

## One device, not two

`device_info` moved into `entity.py`, shared by both platforms. This is a
correctness fix rather than tidying: two entities disagreeing on
identifiers register two devices for one server. Verified below.

## Verified against the live stack

Home Assistant 2025.1.4 and Audiobookshelf 2.36.0 in Podman, with a real
call to api.github.com:

```
entity_id        : update.audiobookshelf_server
state            : off
installed_version: 2.36.0
latest_version   : 2.36.0
release_url      : https://github.com/advplyr/audiobookshelf/releases/tag/v2.36.0
device_class     : firmware
```

```
devices for domain: 1
  identifiers: [['audiobookshelf', '01KYPP...']] sw_version: 2.36.0 entry_type: service
  entity device_ids all match: True
```

13 entities, one device, no GitHub warnings in the log.

77 tests, 12 new: the default-off behaviour, that disabling adds no
entity, tag prefix stripping, the up-to-date case, that the installed
version is re-read each poll, and four parametrised GitHub failure modes
all keeping the last known answer.
