### PR TITLE
docs: explain what recent sessions can and cannot tell you

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -105,6 +105,22 @@ clean `UpdateFailed`.
 Note also that `_get` changed behaviour across library versions: 404 used to return `b""` and
 now raises. Re-check this when bumping `aioaudiobookshelf`.
 
+### Recent sessions compares two different clocks
+
+`PlaybackSession` has **no playing/paused flag**. The whole schema carries `updated_at` and
+nothing describing playback state, so "open sessions the server touched in the last two
+minutes" is the closest the API gets to "currently playing". That is what `count_recent_sessions`
+is, and it is why issue #43 could not be answered more directly.
+
+The catch is that `filter_active_sessions` compares `time.time()`, the Home Assistant host's
+clock, against `updated_at`, which the Audiobookshelf server stamps. Nothing in the response
+carries a server-supplied "now" to use instead. If the host runs more than the idle window
+ahead of the server, every session looks idle and the sensor reads zero while people are
+listening — indistinguishable from the bug #43 originally reported. A host running *behind* is
+harmless, since the difference goes negative and the session still counts.
+
+If someone reports this sensor stuck at zero, check clock drift before reading any code.
+
 ### Platform setup must not call the API
 
 `sensor.py` used to call `/api/libraries` again during `async_setup_entry` to name its

--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@
 | `sensor.audiobookshelf_<library>_duration`   | `sensor` | Total playable content in the library, shown in hours by default |
 | `sensor.audiobookshelf_<library>_size`       | `sensor` | Total disk space used by the library, shown in GB by default |
 
+`recent sessions` counts open sessions the server updated in the last two minutes, which is as close to "currently playing" as the API allows — Audiobookshelf reports no playing or paused flag. It compares your Home Assistant clock against timestamps from the Audiobookshelf server, so if the two drift more than two minutes apart it can read zero while people are listening. Keep both on NTP.
+
 A library created on the server gets its sensors automatically, at the next update. A library removed from the server leaves its sensors behind as `unavailable`; delete them from the entity registry if you want them gone.
 
 ## Optional: update notifications

--- a/custom_components/audiobookshelf/audiobook_shelf_data_update_coordinator.py
+++ b/custom_components/audiobookshelf/audiobook_shelf_data_update_coordinator.py
@@ -58,12 +58,22 @@ class OpenSessionsResponse(_BaseModel):
         self, max_idle_seconds: int = 120
     ) -> list[PlaybackSession]:
         """Filter sessions that have been updated recently."""
+        # PlaybackSession carries no playing/paused flag, so how recently the
+        # server last touched a session is the only signal the API offers for
+        # telling active playback from a session someone left paused.
+        #
+        # Note this compares the Home Assistant host's clock against
+        # updated_at, which the Audiobookshelf server stamps. A host running
+        # more than max_idle_seconds ahead of the server sees every session as
+        # idle and reports zero however many people are listening. There is no
+        # server-supplied "now" anywhere in the response to compare against
+        # instead, so the two clocks have to agree. A host running behind is
+        # harmless: the difference goes negative and the session still counts.
         current_time_ms = int(time.time() * 1000)
         return [
             session
             for session in self.sessions
-            if hasattr(session, "updated_at")
-            and (current_time_ms - session.updated_at) < (max_idle_seconds * 1000)
+            if (current_time_ms - session.updated_at) < (max_idle_seconds * 1000)
         ]
 
 

--- a/info.md
+++ b/info.md
@@ -24,6 +24,8 @@
 | `sensor.audiobookshelf_<library>_duration`   | `sensor` | Total playable content in the library, shown in hours by default |
 | `sensor.audiobookshelf_<library>_size`       | `sensor` | Total disk space used by the library, shown in GB by default |
 
+`recent sessions` counts open sessions the server updated in the last two minutes, which is as close to "currently playing" as the API allows — Audiobookshelf reports no playing or paused flag. It compares your Home Assistant clock against timestamps from the Audiobookshelf server, so if the two drift more than two minutes apart it can read zero while people are listening. Keep both on NTP.
+
 A library created on the server gets its sensors automatically, at the next update. A library removed from the server leaves its sensors behind as `unavailable`; delete them from the entity registry if you want them gone.
 
 ## Optional: update notifications

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -59,6 +59,15 @@ def test_stale_session_is_filtered_out() -> None:
     assert len(response.sessions) == 1
 
 
+def test_session_stamped_ahead_of_the_host_still_counts() -> None:
+    """updated_at comes from the server, so it can be ahead of this clock."""
+    # A host running behind the server yields a negative difference. That must
+    # keep counting the session: it was updated even more recently than "now".
+    ahead_ms = int(time.time() * 1000) + (5 * 60 * 1000)
+    response = _response_with_session_at(ahead_ms)
+    assert len(response.filter_active_sessions()) == 1
+
+
 def test_idle_threshold_boundary_is_respected() -> None:
     """A custom idle window changes which sessions are considered active."""
     ninety_seconds_ago = int(time.time() * 1000) - (90 * 1000)


### PR DESCRIPTION
Relates to #43. Stacked on #142.

Docs and one dead line — no behaviour change.

## What the sensor actually is

`PlaybackSession` has **no playing/paused flag**. The whole schema carries
`updated_at` and nothing describing playback state, so "open sessions the
server touched in the last two minutes" is genuinely the closest the API
gets to "currently playing". That is worth writing down, because it is why
#43 could not be answered more directly rather than a shortcut someone
took.

## The failure mode nobody had recorded

`filter_active_sessions` compares `time.time()` — the **Home Assistant
host's** clock — against `updated_at`, which the **Audiobookshelf
server** stamps. Nothing in the response carries a server-supplied "now"
to use instead.

So a host running more than the idle window ahead of the server sees every
session as idle and reports zero however many people are listening. That
is indistinguishable from the bug #43 originally reported, which makes it
worth a troubleshooting note rather than leaving the next person to
rediscover it.

A host running *behind* is harmless: the difference goes negative and the
session still counts, which is correct — it was updated even more recently
than "now". There is now a test pinning that, since it currently works by
arithmetic rather than by intent.

I looked at fixing it rather than documenting it and there is no clean
way. Comparing each session against the newest `updated_at` in the set
removes the cross-clock problem but breaks the case #43 cares about: with
everyone paused an hour ago, the newest session is an hour old and
everything within two minutes of it still counts as recent. The only real
fix is a server-supplied timestamp, and the API does not offer one.

## Dead guard

`hasattr(session, "updated_at")` is removed. `updated_at` is a required
field, so `from_json` has already raised `MissingField` if it is absent —
the guard reads as protection against missing timestamps and provides
none, which is a live hazard when triaging exactly this sensor.

78 tests. ruff, ruff format and mypy clean.
