### PR TITLE
chore(release): 0.5.0

### DIFF
--- a/custom_components/audiobookshelf/const.py
+++ b/custom_components/audiobookshelf/const.py
@@ -8,7 +8,7 @@ from homeassistant.const import CONF_SCAN_INTERVAL, Platform
 if TYPE_CHECKING:
     from homeassistant.config_entries import ConfigEntry
 
-VERSION = "v0.4.0"
+VERSION = "v0.5.0"
 DOMAIN = "audiobookshelf"
 PLATFORMS: list[Platform] = [Platform.SENSOR, Platform.UPDATE]
 

--- a/custom_components/audiobookshelf/manifest.json
+++ b/custom_components/audiobookshelf/manifest.json
@@ -17,5 +17,5 @@
     "aioaudiobookshelf>=0.1.24,<0.2"
   ],
   "single_config_entry": true,
-  "version": "0.4.0"
+  "version": "0.5.0"
 }


### PR DESCRIPTION
Version bump only, both places per CLAUDE.md:

- `const.py` -> `VERSION = "v0.5.0"`
- `manifest.json` -> `"version": "0.5.0"`

Minor bump: #142 adds a new user-facing feature (the opt-in update
entity) and nothing here is breaking. `hacs.json` unchanged — the minimum
Home Assistant version stays 2025.1.4.

Release gate checked against this tree before tagging:

```
=== v0.5.0 (expect 0) ===
exit=0
=== v0.4.0 stale (expect 1) ===
::error::const.py VERSION is v0.5.0, tag is v0.4.0
::error::manifest.json version is 0.5.0, tag is v0.4.0
exit=1
```

ruff, ruff format, mypy and 78 tests clean.
